### PR TITLE
update fullpath method & add permission for example app

### DIFF
--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <!-- Permissions options for the `manage external storage` group -->
+    <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" />
     <application
         android:label="example"
         android:name="${applicationName}"

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -4,6 +4,7 @@ import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:ftp_server/ftp_server.dart';
 import 'package:ftp_server/server_type.dart';
+import 'package:permission_handler/permission_handler.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 void main() {
@@ -29,7 +30,16 @@ class MyAppState extends State<MyApp> {
   @override
   void initState() {
     super.initState();
+    if (Platform.isAndroid) {
+      _requestPermission();
+    }
     _loadDirectory();
+  }
+
+  Future<void> _requestPermission() async {
+    if (await Permission.manageExternalStorage.isDenied) {
+      await Permission.manageExternalStorage.request();
+    }
   }
 
   Future<void> _loadDirectory() async {

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -32,6 +32,7 @@ dependencies:
     sdk: flutter
   ftp_server:
     path: ../
+  permission_handler: ^11.3.1
   path_provider: ^2.1.3
   shared_preferences: ^2.0.16
   file_picker: ^5.2.5

--- a/lib/ftp_command_handler.dart
+++ b/lib/ftp_command_handler.dart
@@ -68,6 +68,9 @@ class FTPCommandHandler {
       case 'SIZE':
         handleSize(argument, session);
         break;
+      case 'PWD':
+        handleCurPath(argument, session);
+        break;
       default:
         session.sendResponse('502 Command not implemented');
         break;
@@ -170,5 +173,9 @@ class FTPCommandHandler {
 
   void handleSize(String argument, FtpSession session) {
     session.fileSize(argument);
+  }
+
+  void handleCurPath(String argument, FtpSession session) {
+    session.currentPath();
   }
 }

--- a/lib/ftp_session.dart
+++ b/lib/ftp_session.dart
@@ -36,7 +36,7 @@ class FtpSession {
   }
 
   bool _isPathAllowed(String path) {
-    return allowedDirectories.any((allowedDir) => path.startsWith(allowedDir) || path.startsWith("$allowedDir/"));
+    return allowedDirectories.any((allowedDir) => path.startsWith(allowedDir));
   }
 
   String _getFullPath(String path) {


### PR DESCRIPTION
Thank you for your work!

Since directly adding it to the app did not work as expected after startup, I found the source code to test. I hope you can verify if the modifications I made are correct.

1. decode bytes with UTF-8.
2. update fullpath method.
3. sleep 100ms before entering passive mode, but I don't know what happened.
4. request storage permission for example on android.

It works as a server on Android 13, iOS 14, Windows 11, and Ubuntu 24.04. Specifically, iOS 14 uses Finder and Windows 11 uses Xshell to connect to Android 13, Windows 11, and macOS 14 as clients, all of which work normally. However, the file manager on Ubuntu fails to connect to the other three platforms. I noticed that Ubuntu provides more parameters, and I hope you can fix it and let me know once it's done.