### PR TITLE
update full path and fix linux LIST empty

### DIFF
--- a/lib/ftp_command_handler.dart
+++ b/lib/ftp_command_handler.dart
@@ -71,6 +71,9 @@ class FTPCommandHandler {
       case 'PWD':
         handleCurPath(argument, session);
         break;
+      case 'OPTS':
+        handleOptions(argument, session);
+        break;
       default:
         session.sendResponse('502 Command not implemented');
         break;
@@ -177,5 +180,19 @@ class FTPCommandHandler {
 
   void handleCurPath(String argument, FtpSession session) {
     session.currentPath();
+  }
+
+  void handleOptions(String argument, FtpSession session) {
+    var args = argument.split(" ");
+    var option = args[0].toUpperCase();
+    switch (option) {
+      case "UTF8":
+        var mode = args[1].toUpperCase() == "ON";
+        session.sendResponse("200 UTF8 mode ${mode ? 'enable' : 'disable'}");
+        break;
+      default:
+        session.sendResponse('502 Command not implemented');
+        break;
+    }
   }
 }

--- a/lib/ftp_command_handler.dart
+++ b/lib/ftp_command_handler.dart
@@ -94,7 +94,8 @@ class FTPCommandHandler {
 
   void handlePass(String argument, FtpSession session) {
     if ((session.username == null && session.password == null) ||
-        (session.cachedUsername == session.username && argument == session.password)) {
+        (session.cachedUsername == session.username &&
+            argument == session.password)) {
       session.isAuthenticated = true;
       session.sendResponse('230 User logged in, proceed');
     } else {

--- a/lib/ftp_session.dart
+++ b/lib/ftp_session.dart
@@ -35,23 +35,56 @@ class FtpSession {
     controlSocket.listen(processCommand, onDone: closeConnection);
   }
 
+  Future<String> _getIpAddress() async {
+    for (var interface in await NetworkInterface.list()) {
+      for (var addr in interface.addresses) {
+        if (addr.type == InternetAddressType.IPv4 && !addr.isLoopback) {
+          return addr.address;
+        }
+      }
+    }
+    return '0.0.0.0';
+  }
+
   bool _isPathAllowed(String path) {
     return allowedDirectories.any((allowedDir) => path.startsWith(allowedDir));
   }
 
   String _getFullPath(String path) {
-    // todo support argument
-    path = path.split("-")[0];
+    // todo support order argument, eg: ubuntu file manager send: LIST -a
+    if(path == "-a") {
+      path = "";
+    }
+    if (path == "/") {
+      return startingDirectory;
+    }
 
-    if (Platform.isWindows) {
-      return path.isEmpty || path.startsWith("/") ? currentDirectory : path;
+    if(path.isEmpty) {
+      return currentDirectory;
     }
 
     if (path.startsWith(startingDirectory)) {
       return path;
     }
-    path = path.replaceAll("/", " ").trim().replaceAll(" ", "/");
-    return "$currentDirectory${currentDirectory.endsWith("/") ? path : "/$path"}";
+
+    if (Platform.isWindows) {
+      if (path.startsWith("/:")) {
+        return currentDirectory;
+      }
+      if (path.startsWith("/") && path.contains(":")) {
+        return path.replaceFirst("/", "");
+      }
+      path = path.replaceAll("/", "\\");
+      if (path.startsWith("\\")) {
+        return "$startingDirectory\\$path".replaceAll("\\\\", "\\");
+      }
+      return "$currentDirectory\\$path".replaceAll("\\\\", "\\");
+    }
+
+    if (path.startsWith("/")) {
+      return "$startingDirectory/$path".replaceAll("//", "/");
+    }
+    return "$currentDirectory/$path".replaceAll("//", "/");
   }
 
   void processCommand(List<int> data) {
@@ -119,6 +152,9 @@ class FtpSession {
         String fileSize = stat.size.toString();
         String modificationTime = _formatModificationTime(stat.modified);
         String fileName = entity.path.split('/').last;
+        if (Platform.isWindows) {
+          fileName = fileName.split("\\").last;
+        }
         String entry =
             '$permissions 1 ftp ftp $fileSize $modificationTime $fileName\r\n';
         dataSocket!.write(entry);

--- a/lib/ftp_session.dart
+++ b/lib/ftp_session.dart
@@ -52,14 +52,14 @@ class FtpSession {
 
   String _getFullPath(String path) {
     // todo support order argument, eg: ubuntu file manager send: LIST -a
-    if(path == "-a") {
+    if (path == "-a") {
       path = "";
     }
     if (path == "/") {
       return startingDirectory;
     }
 
-    if(path.isEmpty) {
+    if (path.isEmpty) {
       return currentDirectory;
     }
 

--- a/lib/ftp_session.dart
+++ b/lib/ftp_session.dart
@@ -77,10 +77,10 @@ class FtpSession {
     int port = dataListener!.port;
     int p1 = port >> 8;
     int p2 = port & 0xFF;
-    String address = controlSocket.address.address.replaceAll('.', ',');
-
+    // String address = controlSocket.address.address.replaceAll('.', ',');
     // I'm not sure what happened here, the client shows nothing if I comment out this line.
-    await Future.delayed(const Duration(microseconds: 100));
+    // await Future.delayed(const Duration(microseconds: 0));
+    var address = (await _getIpAddress()).replaceAll('.', ',');
     sendResponse('227 Entering Passive Mode ($address,$p1,$p2)');
     dataListener!.first.then((socket) {
       dataSocket = socket;
@@ -112,6 +112,7 @@ class FtpSession {
     Directory dir = Directory(fullPath);
     if (await dir.exists()) {
       List<FileSystemEntity> entities = dir.listSync();
+      sendResponse('150 Opening data connection');
       for (FileSystemEntity entity in entities) {
         var stat = await entity.stat();
         String permissions = _formatPermissions(stat);

--- a/lib/ftp_session.dart
+++ b/lib/ftp_session.dart
@@ -144,7 +144,6 @@ class FtpSession {
     Directory dir = Directory(fullPath);
     if (await dir.exists()) {
       List<FileSystemEntity> entities = dir.listSync();
-      sendResponse('150 Opening data connection');
       for (FileSystemEntity entity in entities) {
         var stat = await entity.stat();
         String permissions = _formatPermissions(stat);


### PR DESCRIPTION
Hello~

I compared an Android app that supports an FTP server and found that it sends an open data connection command before responding with the file list for the LIST command. Additionally, the Ubuntu client shows the files after I add them.

Changes in this PR:

1. Fixed the full path error, which did not consider file or directory names containing spaces or '-'.
2. Linux works as a client .
3. Implemented the UTF-8 option.

The Windows client still has some issues but basically satisfies my needs.
- Occasionally, the LIST command fails to respond because the dataSocket is null when using Windows as the server and Linux as the client, retrying may succeed.