### PR TITLE
Fix connection errors and improve RFC compliance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,10 @@
 
 ## 2.2.0
 
-### Breaking Changes
-- `FTPCommandHandler` constructor no longer takes `controlSocket` parameter
-- `handleCommand` is now `async` (`Future<void>` instead of `void`)
-- `handleMlsd` and `handleMdtm` signatures simplified (removed extra `session` parameter)
+### Internal API Changes
+- `FTPCommandHandler` constructor no longer takes `controlSocket` (it was unused — all communication goes through the session)
+- `FTPCommandHandler.handleCommand` is now `async` to properly await all operations
+- `FtpSession.handleMlsd` and `handleMdtm` no longer take an extra `session` parameter
 - Error responses no longer include server filesystem paths or exception details
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,47 @@
 
 # Changelog
 
+## 2.2.0
+
+### Breaking Changes
+- `FTPCommandHandler` constructor no longer takes `controlSocket` parameter
+- `handleCommand` is now `async` (`Future<void>` instead of `void`)
+- `handleMlsd` and `handleMdtm` signatures simplified (removed extra `session` parameter)
+- Error responses no longer include server filesystem paths or exception details
+
+### Bug Fixes
+- Fixed unhandled `SocketException` crashes when clients disconnect during transfers (#15)
+- Fixed `OPTS UTF8` crash when sent without ON/OFF argument
+- Fixed `EPSV ALL` not being handled (was entering passive mode instead of responding 200)
+- Fixed `ABOR` not sending required 226 follow-up response after 426 (RFC 959)
+- Fixed `PASS` accepted before `USER` when no credentials configured
+- Fixed passive socket file descriptor leak when clients send multiple PASV/EPSV commands
+- Fixed session list memory leak — sessions now auto-remove on disconnect
+- Fixed fire-and-forget async in MKD, RMD, DELE, RNTO, RENAME handlers — all now properly awaited
+- Fixed `handleRnto` rethrowing exceptions without sending response to client
+- Fixed `_getIpAddress` only matching 192.x.x.x networks — now supports 10.x and 172.x, and prefers control socket address
+- Fixed `LIST -la` / `LIST -a` failing — flag arguments are now stripped before directory lookup
+- Fixed pipelined commands (multiple commands in one TCP segment) being silently dropped
+
+### New Commands
+- `NLST` — returns bare filenames only, separated from LIST (was aliased to LIST)
+- `HELP` — returns list of supported commands
+- `STAT` — returns server status
+- `STRU` — accepts F (File), rejects others with 504
+- `MODE` — accepts S (Stream), rejects others with 504
+- `ALLO` — returns 202 (not needed)
+- `ACCT` — returns 202 (not needed)
+- `REIN` — resets authentication state
+- `SITE` — returns 502 (not implemented)
+
+### Improvements
+- Authentication enforcement: commands require login when credentials are configured
+- `TYPE` now accepts `TYPE A N` form (ASCII Non-print) per RFC 959
+- `FEAT` now advertises MLSD capability
+- `USER` validates non-empty argument
+- Error responses sanitized — no server path or exception leakage to clients
+- `activeSessions` now returns unmodifiable list
+
 ## 2.1.1
 - Updated README documentation to include new rename commands
 

--- a/lib/ftp_command_handler.dart
+++ b/lib/ftp_command_handler.dart
@@ -11,7 +11,7 @@ class FTPCommandHandler {
 
   /// Commands that are allowed before authentication
   static const _preAuthCommands = {
-    'USER', 'PASS', 'QUIT', 'FEAT', 'SYST', 'NOOP',
+    'USER', 'PASS', 'QUIT', 'FEAT', 'SYST', 'NOOP', 'OPTS',
   };
 
   void handleCommand(String commandLine, FtpSession session) {
@@ -164,11 +164,14 @@ class FTPCommandHandler {
   }
 
   /// Strips LIST flags (e.g., -la, -a) that clients like FileZilla send.
-  /// Returns the path portion of the argument.
+  /// Only strips tokens that look like flags (start with '-' and contain
+  /// no path separators), preserving valid paths like "-backups".
   String _stripListFlags(String argument) {
     if (argument.isEmpty) return argument;
     final parts = argument.split(' ');
-    final filtered = parts.where((p) => !p.startsWith('-')).join(' ').trim();
+    final filtered = parts.where((p) {
+      return !(p.startsWith('-') && !p.contains('/') && !p.contains('\\'));
+    }).join(' ').trim();
     return filtered;
   }
 
@@ -342,14 +345,8 @@ class FTPCommandHandler {
       return;
     }
 
-    try {
-      // Perform the rename operation
-      session.renameFileOrDirectory(session.pendingRenameFrom!, argument);
-    } catch (e) {
-      // Clear the pending rename state on error
-      session.pendingRenameFrom = null;
-      rethrow;
-    }
+    // renameFileOrDirectory handles errors and responses internally
+    session.renameFileOrDirectory(session.pendingRenameFrom!, argument);
   }
 
   void handleRename(String argument, FtpSession session) {

--- a/lib/ftp_command_handler.dart
+++ b/lib/ftp_command_handler.dart
@@ -1,20 +1,18 @@
-import 'dart:io';
 import 'package:ftp_server/ftp_session.dart';
 import 'package:ftp_server/server_type.dart';
 import 'logger_handler.dart';
 
 class FTPCommandHandler {
-  final Socket controlSocket;
   final LoggerHandler logger;
 
-  FTPCommandHandler(this.controlSocket, this.logger);
+  FTPCommandHandler(this.logger);
 
   /// Commands that are allowed before authentication
   static const _preAuthCommands = {
     'USER', 'PASS', 'QUIT', 'FEAT', 'SYST', 'NOOP', 'OPTS',
   };
 
-  void handleCommand(String commandLine, FtpSession session) {
+  Future<void> handleCommand(String commandLine, FtpSession session) async {
     List<String> parts = commandLine.split(' ');
     String command = parts[0].toUpperCase();
     String argument =
@@ -38,54 +36,70 @@ class FTPCommandHandler {
         handlePass(argument, session);
         break;
       case 'QUIT':
-        handleQuit(session);
+        await handleQuit(session);
         break;
       case 'PASV':
-        handlePasv(session);
+        await session.enterPassiveMode();
         break;
       case 'PORT':
-        handlePort(argument, session);
+        await session.enterActiveMode(argument);
         break;
       case 'LIST':
-        handleList(argument, session);
+        await session.listDirectory(_stripListFlags(argument));
         break;
       case 'NLST':
-        handleNlst(argument, session);
+        await session.listDirectoryNames(_stripListFlags(argument));
         break;
       case 'RETR':
-        handleRetr(argument, session);
+        await session.retrieveFile(argument);
         break;
       case 'STOR':
-        handleStor(argument, session);
+        if (session.serverType == ServerType.readOnly) {
+          session.sendResponse('550 Command not allowed in read-only mode');
+        } else {
+          await session.storeFile(argument);
+        }
         break;
       case 'CWD':
-        handleCwd(argument, session);
+        session.changeDirectory(argument);
         break;
       case 'CDUP':
-        handleCdup(session);
+        session.changeToParentDirectory();
         break;
       case 'MKD':
       case 'XMKD':
-        handleMkd(argument, session);
+        if (session.serverType == ServerType.readOnly) {
+          session.sendResponse('550 Command not allowed in read-only mode');
+        } else {
+          await session.makeDirectory(argument);
+        }
         break;
       case 'RMD':
       case 'XRMD':
-        handleRmd(argument, session);
+        if (session.serverType == ServerType.readOnly) {
+          session.sendResponse('550 Command not allowed in read-only mode');
+        } else {
+          await session.removeDirectory(argument);
+        }
         break;
       case 'DELE':
-        handleDele(argument, session);
+        if (session.serverType == ServerType.readOnly) {
+          session.sendResponse('550 Command not allowed in read-only mode');
+        } else {
+          await session.deleteFile(argument);
+        }
         break;
       case 'SYST':
-        handleSyst(session);
+        session.sendResponse('215 UNIX Type: L8');
         break;
       case 'NOOP':
-        handleNoop(session);
+        session.sendResponse('200 NOOP command successful');
         break;
       case 'TYPE':
         handleType(argument, session);
         break;
       case 'SIZE':
-        handleSize(argument, session);
+        await session.fileSize(argument);
         break;
       case 'PWD':
       case 'XPWD':
@@ -98,25 +112,25 @@ class FTPCommandHandler {
         handleFeat(session);
         break;
       case 'EPSV':
-        handleEpsv(argument, session);
+        await handleEpsv(argument, session);
         break;
       case 'ABOR':
-        handleAbort(session);
+        session.abortTransfer();
         break;
       case 'MLSD':
-        handleMlsd(argument, session);
+        await session.handleMlsd(argument);
         break;
       case 'MDTM':
-        handleMdtm(argument, session);
+        session.handleMdtm(argument);
         break;
       case 'RNFR':
         handleRnfr(argument, session);
         break;
       case 'RNTO':
-        handleRnto(argument, session);
+        await handleRnto(argument, session);
         break;
       case 'RENAME':
-        handleRename(argument, session);
+        await handleRename(argument, session);
         break;
       case 'STRU':
         handleStru(argument, session);
@@ -127,6 +141,23 @@ class FTPCommandHandler {
       case 'ALLO':
         session.sendResponse('202 ALLO command not needed');
         break;
+      case 'STAT':
+        session.sendResponse('211 Server is running');
+        break;
+      case 'HELP':
+        handleHelp(session);
+        break;
+      case 'SITE':
+        session.sendResponse('502 SITE command not implemented');
+        break;
+      case 'ACCT':
+        session.sendResponse('202 ACCT command not needed');
+        break;
+      case 'REIN':
+        session.isAuthenticated = false;
+        session.cachedUsername = null;
+        session.sendResponse('220 Service ready for new user');
+        break;
       default:
         session.sendResponse('502 Command not implemented');
         break;
@@ -134,12 +165,20 @@ class FTPCommandHandler {
   }
 
   void handleUser(String argument, FtpSession session) {
+    if (argument.isEmpty) {
+      session.sendResponse('501 Syntax error in parameters');
+      return;
+    }
     session.cachedUsername = argument;
     session.isAuthenticated = false;
     session.sendResponse('331 Password required for $argument');
   }
 
   void handlePass(String argument, FtpSession session) {
+    if (session.cachedUsername == null) {
+      session.sendResponse('503 Bad sequence of commands');
+      return;
+    }
     if ((session.username == null && session.password == null) ||
         (session.cachedUsername == session.username &&
             argument == session.password)) {
@@ -152,15 +191,7 @@ class FTPCommandHandler {
 
   Future<void> handleQuit(FtpSession session) async {
     session.sendResponse('221 Service closing control connection');
-    await session.controlSocket.close();
-  }
-
-  void handlePasv(FtpSession session) {
-    session.enterPassiveMode();
-  }
-
-  void handlePort(String argument, FtpSession session) {
-    session.enterActiveMode(argument);
+    session.closeConnection();
   }
 
   /// Strips LIST flags (e.g., -la, -a) that clients like FileZilla send.
@@ -175,75 +206,11 @@ class FTPCommandHandler {
     return filtered;
   }
 
-  void handleList(String argument, FtpSession session) {
-    session.listDirectory(_stripListFlags(argument));
-  }
-
-  void handleNlst(String argument, FtpSession session) {
-    session.listDirectoryNames(_stripListFlags(argument));
-  }
-
-  void handleRetr(String argument, FtpSession session) {
-    session.retrieveFile(argument);
-  }
-
-  void handleMlsd(String argument, FtpSession session) {
-    session.handleMlsd(argument, session);
-  }
-
-  void handleMdtm(String argument, FtpSession session) {
-    session.handleMdtm(argument, session);
-  }
-
-  void handleStor(String argument, FtpSession session) {
-    if (session.serverType == ServerType.readOnly) {
-      session.sendResponse('550 Command not allowed in read-only mode');
-    } else {
-      session.storeFile(argument);
-    }
-  }
-
-  void handleCwd(String argument, FtpSession session) {
-    session.changeDirectory(argument);
-  }
-
-  void handleCdup(FtpSession session) {
-    session.changeToParentDirectory();
-  }
-
-  void handleMkd(String argument, FtpSession session) {
-    if (session.serverType == ServerType.readOnly) {
-      session.sendResponse('550 Command not allowed in read-only mode');
-    } else {
-      session.makeDirectory(argument);
-    }
-  }
-
-  void handleRmd(String argument, FtpSession session) {
-    if (session.serverType == ServerType.readOnly) {
-      session.sendResponse('550 Command not allowed in read-only mode');
-    } else {
-      session.removeDirectory(argument);
-    }
-  }
-
-  void handleDele(String argument, FtpSession session) {
-    if (session.serverType == ServerType.readOnly) {
-      session.sendResponse('550 Command not allowed in read-only mode');
-    } else {
-      session.deleteFile(argument);
-    }
-  }
-
-  void handleSyst(FtpSession session) {
-    session.sendResponse('215 UNIX Type: L8');
-  }
-
-  void handleNoop(FtpSession session) {
-    session.sendResponse('200 NOOP command successful');
-  }
-
   void handleType(String argument, FtpSession session) {
+    if (argument.isEmpty) {
+      session.sendResponse('501 Syntax error in parameters');
+      return;
+    }
     // Handle TYPE A, TYPE I, and TYPE A N (ASCII Non-print) forms
     final type = argument.split(' ').first.toUpperCase();
     if (type == 'A' || type == 'I') {
@@ -253,16 +220,16 @@ class FTPCommandHandler {
     }
   }
 
-  void handleSize(String argument, FtpSession session) {
-    session.fileSize(argument);
-  }
-
   void handleCurPath(FtpSession session) {
     String currentPath = session.fileOperations.getCurrentDirectory();
     session.sendResponse('257 "$currentPath" is current directory');
   }
 
   void handleOptions(String argument, FtpSession session) {
+    if (argument.isEmpty) {
+      session.sendResponse('501 Syntax error in parameters');
+      return;
+    }
     var args = argument.split(" ");
     var option = args[0].toUpperCase();
     switch (option) {
@@ -282,7 +249,6 @@ class FTPCommandHandler {
 
   void handleFeat(FtpSession session) {
     session.sendResponse('211-Features:');
-
     session.sendResponse(' SIZE');
     session.sendResponse(' MDTM');
     session.sendResponse(' MLSD');
@@ -292,17 +258,12 @@ class FTPCommandHandler {
     session.sendResponse('211 End');
   }
 
-  void handleEpsv(String argument, FtpSession session) {
+  Future<void> handleEpsv(String argument, FtpSession session) async {
     if (argument.toUpperCase() == 'ALL') {
-      // EPSV ALL tells the server the client will only use EPSV from now on
       session.sendResponse('200 EPSV ALL command successful');
     } else {
-      session.enterExtendedPassiveMode();
+      await session.enterExtendedPassiveMode();
     }
-  }
-
-  void handleAbort(FtpSession session) {
-    session.abortTransfer();
   }
 
   void handleRnfr(String argument, FtpSession session) {
@@ -310,81 +271,63 @@ class FTPCommandHandler {
       session.sendResponse('550 Command not allowed in read-only mode');
       return;
     }
-
     if (argument.isEmpty) {
       session.sendResponse('501 Syntax error in parameters or arguments');
       return;
     }
-
-    // Check if the file/directory exists
     if (!session.fileOperations.exists(argument)) {
       session.sendResponse('550 File not found');
       return;
     }
-
-    // Store the source path for the rename operation
     session.pendingRenameFrom = argument;
     session
         .sendResponse('350 Requested file action pending further information');
   }
 
-  void handleRnto(String argument, FtpSession session) {
+  Future<void> handleRnto(String argument, FtpSession session) async {
     if (session.serverType == ServerType.readOnly) {
       session.sendResponse('550 Command not allowed in read-only mode');
       return;
     }
-
     if (argument.isEmpty) {
       session.sendResponse('501 Syntax error in parameters or arguments');
       return;
     }
-
-    // Check if RNFR was called first
     if (session.pendingRenameFrom == null) {
       session.sendResponse('503 Bad sequence of commands');
       return;
     }
-
-    // renameFileOrDirectory handles errors and responses internally
-    session.renameFileOrDirectory(session.pendingRenameFrom!, argument);
+    await session.renameFileOrDirectory(session.pendingRenameFrom!, argument);
   }
 
-  void handleRename(String argument, FtpSession session) {
+  Future<void> handleRename(String argument, FtpSession session) async {
     if (session.serverType == ServerType.readOnly) {
       session.sendResponse('550 Command not allowed in read-only mode');
       return;
     }
-
     if (argument.isEmpty) {
       session.sendResponse('501 Syntax error in parameters or arguments');
       return;
     }
-
-    // Parse the rename command arguments (oldname newname)
     final parts = argument.split(' ');
     if (parts.length != 2) {
       session.sendResponse('501 Syntax error in parameters or arguments');
       return;
     }
-
     final oldName = parts[0];
     final newName = parts[1];
-
-    // Check if the file/directory exists
     if (!session.fileOperations.exists(oldName)) {
       session.sendResponse('550 File not found');
       return;
     }
-
-    try {
-      // Perform the rename operation directly
-      session.renameFileOrDirectory(oldName, newName);
-    } catch (e) {
-      // Error handling is done in the session method
-    }
+    await session.renameFileOrDirectory(oldName, newName);
   }
 
   void handleStru(String argument, FtpSession session) {
+    if (argument.isEmpty) {
+      session.sendResponse('501 Syntax error in parameters');
+      return;
+    }
     if (argument.toUpperCase() == 'F') {
       session.sendResponse('200 Structure set to File');
     } else {
@@ -393,10 +336,25 @@ class FTPCommandHandler {
   }
 
   void handleMode(String argument, FtpSession session) {
+    if (argument.isEmpty) {
+      session.sendResponse('501 Syntax error in parameters');
+      return;
+    }
     if (argument.toUpperCase() == 'S') {
       session.sendResponse('200 Mode set to Stream');
     } else {
       session.sendResponse('504 Mode not supported');
     }
+  }
+
+  void handleHelp(FtpSession session) {
+    session.sendResponse('214-The following commands are supported:');
+    session.sendResponse(
+        ' USER PASS QUIT PASV PORT EPSV LIST NLST RETR STOR');
+    session.sendResponse(
+        ' CWD CDUP MKD RMD DELE PWD TYPE SIZE FEAT OPTS SYST');
+    session.sendResponse(
+        ' NOOP ABOR MLSD MDTM RNFR RNTO STRU MODE ALLO HELP');
+    session.sendResponse('214 End');
   }
 }

--- a/lib/ftp_command_handler.dart
+++ b/lib/ftp_command_handler.dart
@@ -9,12 +9,26 @@ class FTPCommandHandler {
 
   FTPCommandHandler(this.controlSocket, this.logger);
 
+  /// Commands that are allowed before authentication
+  static const _preAuthCommands = {
+    'USER', 'PASS', 'QUIT', 'FEAT', 'SYST', 'NOOP',
+  };
+
   void handleCommand(String commandLine, FtpSession session) {
     List<String> parts = commandLine.split(' ');
     String command = parts[0].toUpperCase();
-    String argument = parts.length > 1 ? parts.sublist(1).join(' ').trim() : '';
+    String argument =
+        parts.length > 1 ? parts.sublist(1).join(' ').trim() : '';
 
     logger.logCommand(command, argument);
+
+    // Enforce authentication when credentials are configured
+    if (!session.isAuthenticated &&
+        !_preAuthCommands.contains(command) &&
+        (session.username != null || session.password != null)) {
+      session.sendResponse('530 Not logged in');
+      return;
+    }
 
     switch (command) {
       case 'USER':
@@ -33,8 +47,10 @@ class FTPCommandHandler {
         handlePort(argument, session);
         break;
       case 'LIST':
-      case 'NLST':
         handleList(argument, session);
+        break;
+      case 'NLST':
+        handleNlst(argument, session);
         break;
       case 'RETR':
         handleRetr(argument, session);
@@ -82,7 +98,7 @@ class FTPCommandHandler {
         handleFeat(session);
         break;
       case 'EPSV':
-        handleEpsv(session);
+        handleEpsv(argument, session);
         break;
       case 'ABOR':
         handleAbort(session);
@@ -102,8 +118,17 @@ class FTPCommandHandler {
       case 'RENAME':
         handleRename(argument, session);
         break;
+      case 'STRU':
+        handleStru(argument, session);
+        break;
+      case 'MODE':
+        handleMode(argument, session);
+        break;
+      case 'ALLO':
+        session.sendResponse('202 ALLO command not needed');
+        break;
       default:
-        session.sendResponse('502 Command not implemented $command $argument');
+        session.sendResponse('502 Command not implemented');
         break;
     }
   }
@@ -138,8 +163,21 @@ class FTPCommandHandler {
     session.enterActiveMode(argument);
   }
 
+  /// Strips LIST flags (e.g., -la, -a) that clients like FileZilla send.
+  /// Returns the path portion of the argument.
+  String _stripListFlags(String argument) {
+    if (argument.isEmpty) return argument;
+    final parts = argument.split(' ');
+    final filtered = parts.where((p) => !p.startsWith('-')).join(' ').trim();
+    return filtered;
+  }
+
   void handleList(String argument, FtpSession session) {
-    session.listDirectory(argument);
+    session.listDirectory(_stripListFlags(argument));
+  }
+
+  void handleNlst(String argument, FtpSession session) {
+    session.listDirectoryNames(_stripListFlags(argument));
   }
 
   void handleRetr(String argument, FtpSession session) {
@@ -203,10 +241,12 @@ class FTPCommandHandler {
   }
 
   void handleType(String argument, FtpSession session) {
-    if (argument == 'A' || argument == 'I') {
-      session.sendResponse('200 Type set to $argument');
+    // Handle TYPE A, TYPE I, and TYPE A N (ASCII Non-print) forms
+    final type = argument.split(' ').first.toUpperCase();
+    if (type == 'A' || type == 'I') {
+      session.sendResponse('200 Type set to $type');
     } else {
-      session.sendResponse('500 Syntax error, command unrecognized');
+      session.sendResponse('504 Type not supported');
     }
   }
 
@@ -224,11 +264,15 @@ class FTPCommandHandler {
     var option = args[0].toUpperCase();
     switch (option) {
       case "UTF8":
+        if (args.length < 2) {
+          session.sendResponse('501 Syntax error in parameters');
+          return;
+        }
         var mode = args[1].toUpperCase() == "ON";
         session.sendResponse("200 UTF8 mode ${mode ? 'enable' : 'disable'}");
         break;
       default:
-        session.sendResponse('502 Command not implemented handleOptions');
+        session.sendResponse('502 Command not implemented');
         break;
     }
   }
@@ -238,14 +282,20 @@ class FTPCommandHandler {
 
     session.sendResponse(' SIZE');
     session.sendResponse(' MDTM');
+    session.sendResponse(' MLSD');
     session.sendResponse(' EPSV');
     session.sendResponse(' PASV');
     session.sendResponse(' UTF8');
     session.sendResponse('211 End');
   }
 
-  void handleEpsv(FtpSession session) {
-    session.enterExtendedPassiveMode();
+  void handleEpsv(String argument, FtpSession session) {
+    if (argument.toUpperCase() == 'ALL') {
+      // EPSV ALL tells the server the client will only use EPSV from now on
+      session.sendResponse('200 EPSV ALL command successful');
+    } else {
+      session.enterExtendedPassiveMode();
+    }
   }
 
   void handleAbort(FtpSession session) {
@@ -334,6 +384,22 @@ class FTPCommandHandler {
       session.renameFileOrDirectory(oldName, newName);
     } catch (e) {
       // Error handling is done in the session method
+    }
+  }
+
+  void handleStru(String argument, FtpSession session) {
+    if (argument.toUpperCase() == 'F') {
+      session.sendResponse('200 Structure set to File');
+    } else {
+      session.sendResponse('504 Structure not supported');
+    }
+  }
+
+  void handleMode(String argument, FtpSession session) {
+    if (argument.toUpperCase() == 'S') {
+      session.sendResponse('200 Mode set to Stream');
+    } else {
+      session.sendResponse('504 Mode not supported');
     }
   }
 }

--- a/lib/ftp_command_handler.dart
+++ b/lib/ftp_command_handler.dart
@@ -9,14 +9,19 @@ class FTPCommandHandler {
 
   /// Commands that are allowed before authentication
   static const _preAuthCommands = {
-    'USER', 'PASS', 'QUIT', 'FEAT', 'SYST', 'NOOP', 'OPTS',
+    'USER',
+    'PASS',
+    'QUIT',
+    'FEAT',
+    'SYST',
+    'NOOP',
+    'OPTS',
   };
 
   Future<void> handleCommand(String commandLine, FtpSession session) async {
     List<String> parts = commandLine.split(' ');
     String command = parts[0].toUpperCase();
-    String argument =
-        parts.length > 1 ? parts.sublist(1).join(' ').trim() : '';
+    String argument = parts.length > 1 ? parts.sublist(1).join(' ').trim() : '';
 
     logger.logCommand(command, argument);
 
@@ -200,9 +205,12 @@ class FTPCommandHandler {
   String _stripListFlags(String argument) {
     if (argument.isEmpty) return argument;
     final parts = argument.split(' ');
-    final filtered = parts.where((p) {
-      return !(p.startsWith('-') && !p.contains('/') && !p.contains('\\'));
-    }).join(' ').trim();
+    final filtered = parts
+        .where((p) {
+          return !(p.startsWith('-') && !p.contains('/') && !p.contains('\\'));
+        })
+        .join(' ')
+        .trim();
     return filtered;
   }
 
@@ -349,12 +357,9 @@ class FTPCommandHandler {
 
   void handleHelp(FtpSession session) {
     session.sendResponse('214-The following commands are supported:');
-    session.sendResponse(
-        ' USER PASS QUIT PASV PORT EPSV LIST NLST RETR STOR');
-    session.sendResponse(
-        ' CWD CDUP MKD RMD DELE PWD TYPE SIZE FEAT OPTS SYST');
-    session.sendResponse(
-        ' NOOP ABOR MLSD MDTM RNFR RNTO STRU MODE ALLO HELP');
+    session.sendResponse(' USER PASS QUIT PASV PORT EPSV LIST NLST RETR STOR');
+    session.sendResponse(' CWD CDUP MKD RMD DELE PWD TYPE SIZE FEAT OPTS SYST');
+    session.sendResponse(' NOOP ABOR MLSD MDTM RNFR RNTO STRU MODE ALLO HELP');
     session.sendResponse('214 End');
   }
 }

--- a/lib/ftp_server.dart
+++ b/lib/ftp_server.dart
@@ -36,12 +36,11 @@ class FtpServer {
   /// The file operations backend to use (VirtualFileOperations, PhysicalFileOperations, or custom).
   final FileOperations fileOperations;
 
-  ///Create a List to collect new sessions.
-  ///When you call _server?.stop() it should disconnect all active connections.
+  /// Active sessions. Sessions are automatically removed when they disconnect.
   final List<FtpSession> _sessionList = [];
 
   /// Get the list of current active sessions.
-  List<FtpSession> get activeSessions => _sessionList;
+  List<FtpSession> get activeSessions => List.unmodifiable(_sessionList);
 
   /// Creates an FTP server with the provided configurations.
   ///
@@ -49,8 +48,6 @@ class FtpServer {
   /// The [fileOperations] must be provided and handles all file/directory logic.
   /// The [serverType] determines the mode (read-only or read and write) of the server.
   /// Optional parameters include [username], [password], and [logFunction].
-  ///
-  /// BREAKING CHANGE: `sharedDirectories` and `startingDirectory` are removed. All directory logic is now handled by the provided [fileOperations].
   FtpServer(this.port,
       {this.username,
       this.password,
@@ -59,22 +56,30 @@ class FtpServer {
       Function(String)? logFunction})
       : logger = LoggerHandler(logFunction);
 
+  FtpSession _createSession(Socket socket) {
+    late FtpSession session;
+    session = FtpSession(
+      socket,
+      username: username,
+      password: password,
+      fileOperations: fileOperations,
+      serverType: serverType,
+      logger: logger,
+      onDisconnect: () {
+        _sessionList.remove(session);
+      },
+    );
+    _sessionList.add(session);
+    return session;
+  }
+
   Future<void> start() async {
     _server = await ServerSocket.bind(InternetAddress.anyIPv4, port);
     logger.generalLog('FTP Server is running on port $port');
     await for (var socket in _server!) {
       logger.generalLog(
           'New client connected from ${socket.remoteAddress.address}:${socket.remotePort}');
-      var session = FtpSession(
-        socket,
-        username: username,
-        password: password,
-        fileOperations: fileOperations,
-        serverType: serverType,
-        logger: logger,
-      );
-      //Fill sessionList with new sessions.
-      _sessionList.add(session);
+      _createSession(socket);
     }
   }
 
@@ -84,22 +89,12 @@ class FtpServer {
     _server!.listen((socket) {
       logger.generalLog(
           'New client connected from ${socket.remoteAddress.address}:${socket.remotePort}');
-      var session = FtpSession(
-        socket,
-        username: username,
-        password: password,
-        fileOperations: fileOperations,
-        serverType: serverType,
-        logger: logger,
-      );
-      //Fill sessionList with new sessions.
-      _sessionList.add(session);
+      _createSession(socket);
     });
   }
 
   Future<void> stop() async {
-    //Disconnect all active sessions
-    for (var session in _sessionList) {
+    for (var session in List.of(_sessionList)) {
       session.closeConnection();
     }
     _sessionList.clear();

--- a/lib/ftp_session.dart
+++ b/lib/ftp_session.dart
@@ -50,6 +50,7 @@ class FtpSession {
   }
 
   final StringBuffer _commandBuffer = StringBuffer();
+  Future<void> _commandQueue = Future.value();
 
   void processCommand(List<int> data) {
     try {
@@ -62,7 +63,15 @@ class FtpSession {
       for (final line in lines.sublist(0, lines.length - 1)) {
         final trimmed = line.trim();
         if (trimmed.isEmpty) continue;
-        commandHandler.handleCommand(trimmed, this);
+        // Chain commands sequentially so async handlers complete before the next runs
+        _commandQueue = _commandQueue.then((_) async {
+          try {
+            await commandHandler.handleCommand(trimmed, this);
+          } catch (e, s) {
+            logger.generalLog("error: $e stack: $s");
+            sendResponse('500 Internal server error');
+          }
+        });
       }
     } catch (e, s) {
       logger.generalLog("error: $e stack: $s ,input bytes $data");

--- a/lib/ftp_session.dart
+++ b/lib/ftp_session.dart
@@ -51,10 +51,21 @@ class FtpSession {
     );
   }
 
+  final StringBuffer _commandBuffer = StringBuffer();
+
   void processCommand(List<int> data) {
     try {
-      String commandLine = utf8.decode(data).trim();
-      commandHandler.handleCommand(commandLine, this);
+      _commandBuffer.write(utf8.decode(data));
+      final raw = _commandBuffer.toString();
+      final lines = raw.split('\r\n');
+      // Keep the last (potentially incomplete) fragment in the buffer
+      _commandBuffer.clear();
+      _commandBuffer.write(lines.last);
+      for (final line in lines.sublist(0, lines.length - 1)) {
+        final trimmed = line.trim();
+        if (trimmed.isEmpty) continue;
+        commandHandler.handleCommand(trimmed, this);
+      }
     } catch (e, s) {
       logger.generalLog("error: $e stack: $s ,input bytes $data");
       sendResponse('500 Internal server error');
@@ -118,6 +129,12 @@ class FtpSession {
 
   Future<void> enterPassiveMode() async {
     try {
+      // Close any previous passive listener to avoid leaking sockets
+      dataListener?.close();
+      dataListener = null;
+      dataSocket?.close();
+      dataSocket = null;
+
       dataListener = await ServerSocket.bind(InternetAddress.anyIPv4, 0);
       int port = dataListener!.port;
       int p1 = port >> 8;
@@ -473,9 +490,11 @@ class FtpSession {
         logger.generalLog('Error closing data listener during abort: $e');
       }
       dataListener = null;
+      // RFC 959: ABOR during transfer requires 426 followed by 226
       sendResponse('426 Transfer aborted');
+      sendResponse('226 ABOR command successful');
     } else {
-      sendResponse('226 No transfer in progress');
+      sendResponse('226 ABOR command successful');
     }
   }
 
@@ -543,6 +562,12 @@ class FtpSession {
 
   Future<void> enterExtendedPassiveMode() async {
     try {
+      // Close any previous passive listener to avoid leaking sockets
+      dataListener?.close();
+      dataListener = null;
+      dataSocket?.close();
+      dataSocket = null;
+
       dataListener = await ServerSocket.bind(InternetAddress.anyIPv4, 0);
       int port = dataListener!.port;
       sendResponse('229 Entering Extended Passive Mode (|||$port|)');

--- a/lib/ftp_session.dart
+++ b/lib/ftp_session.dart
@@ -50,7 +50,8 @@ class FtpSession {
   }
 
   final StringBuffer _commandBuffer = StringBuffer();
-  Future<void> _commandQueue = Future.value();
+  final List<String> _pendingCommands = [];
+  bool _processing = false;
 
   void processCommand(List<int> data) {
     try {
@@ -63,29 +64,31 @@ class FtpSession {
       for (final line in lines.sublist(0, lines.length - 1)) {
         final trimmed = line.trim();
         if (trimmed.isEmpty) continue;
-        // Chain commands sequentially so async handlers complete before the next runs
-        _commandQueue = _commandQueue.then((_) async {
-          try {
-            await commandHandler.handleCommand(trimmed, this);
-            // Flush after each command so the response is sent before the
-            // next command runs. Without this, microtask-chained responses
-            // can pile up in the socket buffer and confuse some FTP clients.
-            try {
-              await controlSocket.flush();
-            } catch (_) {
-              // Socket may already be closed (e.g. after QUIT)
-            }
-          } catch (e, s) {
-            logger.generalLog("error: $e stack: $s");
-            try {
-              sendResponse('500 Internal server error');
-            } catch (_) {}
-          }
-        });
+        _pendingCommands.add(trimmed);
       }
+      _processQueue();
     } catch (e, s) {
       logger.generalLog("error: $e stack: $s ,input bytes $data");
       sendResponse('500 Internal server error');
+    }
+  }
+
+  /// Processes queued commands one at a time.
+  Future<void> _processQueue() async {
+    if (_processing) return;
+    _processing = true;
+    try {
+      while (_pendingCommands.isNotEmpty) {
+        final command = _pendingCommands.removeAt(0);
+        try {
+          await commandHandler.handleCommand(command, this);
+        } catch (e, s) {
+          logger.generalLog("error: $e stack: $s");
+          sendResponse('500 Internal server error');
+        }
+      }
+    } finally {
+      _processing = false;
     }
   }
 

--- a/lib/ftp_session.dart
+++ b/lib/ftp_session.dart
@@ -41,7 +41,14 @@ class FtpSession {
         commandHandler = FTPCommandHandler(controlSocket, logger) {
     sendResponse('220 Welcome to the FTP server');
     logger.generalLog('FtpSession created. Ready to process commands.');
-    controlSocket.listen(processCommand, onDone: closeConnection);
+    controlSocket.listen(
+      processCommand,
+      onDone: closeConnection,
+      onError: (error) {
+        logger.generalLog('Control socket error: $error');
+        closeConnection();
+      },
+    );
   }
 
   void processCommand(List<int> data) {
@@ -64,9 +71,23 @@ class FtpSession {
   }
 
   void closeConnection() {
-    controlSocket.close();
-    dataSocket?.close();
-    dataListener?.close();
+    try {
+      controlSocket.close();
+    } catch (e) {
+      logger.generalLog('Error closing control socket: $e');
+    }
+    try {
+      dataSocket?.close();
+    } catch (e) {
+      logger.generalLog('Error closing data socket: $e');
+    }
+    try {
+      dataListener?.close();
+    } catch (e) {
+      logger.generalLog('Error closing data listener: $e');
+    }
+    dataSocket = null;
+    dataListener = null;
     logger.generalLog('Connection closed');
   }
 
@@ -207,6 +228,45 @@ class FtpSession {
     }
   }
 
+  /// NLST: list only filenames, one per line (RFC 959).
+  Future<void> listDirectoryNames(String path) async {
+    if (!await openDataConnection()) {
+      return;
+    }
+
+    try {
+      transferInProgress = true;
+      var dirContents = await fileOperations.listDirectory(path);
+
+      for (FileSystemEntity entity in dirContents) {
+        if (!transferInProgress || dataSocket == null) break;
+
+        try {
+          String fileName = entity.path.split(Platform.pathSeparator).last;
+          dataSocket!.write('$fileName\r\n');
+        } catch (e) {
+          logger.generalLog('Socket write error during NLST: $e');
+          transferInProgress = false;
+          break;
+        }
+      }
+
+      if (transferInProgress) {
+        transferInProgress = false;
+        await _closeDataSocket();
+        sendResponse('226 Transfer complete');
+      } else {
+        await _closeDataSocket();
+        sendResponse('426 Transfer aborted');
+      }
+    } catch (e) {
+      logger.generalLog('Error listing directory names: $e');
+      sendResponse('550 Failed to list directory');
+      transferInProgress = false;
+      await _closeDataSocket();
+    }
+  }
+
   String _formatPermissions(FileStat stat) {
     String type = stat.type == FileSystemEntityType.directory ? 'd' : '-';
     String owner = _permissionToString(stat.mode >> 6);
@@ -280,7 +340,7 @@ class FtpSession {
           cancelOnError: true,
         );
       } else {
-        sendResponse('550 File not found $fullPath');
+        sendResponse('550 File not found');
         transferInProgress = false;
         await _closeDataSocket();
       }
@@ -350,7 +410,7 @@ class FtpSession {
       );
     } catch (e) {
       logger.generalLog('Exception in storeFile: $e');
-      sendResponse('550 Error creating file or directory: $e');
+      sendResponse('550 Error creating file or directory');
       transferInProgress = false;
       fileSink
           ?.close()
@@ -398,13 +458,22 @@ class FtpSession {
     }
   }
 
-// Method to abort a file transfer
   void abortTransfer() async {
     if (transferInProgress) {
       transferInProgress = false;
-      dataSocket?.destroy(); // Forcefully close the data socket
-      sendResponse('426 Transfer aborted');
+      try {
+        dataSocket?.destroy();
+      } catch (e) {
+        logger.generalLog('Error destroying data socket during abort: $e');
+      }
       dataSocket = null;
+      try {
+        dataListener?.close();
+      } catch (e) {
+        logger.generalLog('Error closing data listener during abort: $e');
+      }
+      dataListener = null;
+      sendResponse('426 Transfer aborted');
     } else {
       sendResponse('226 No transfer in progress');
     }

--- a/lib/ftp_session.dart
+++ b/lib/ftp_session.dart
@@ -24,21 +24,19 @@ class FtpSession {
   bool transferInProgress = false;
   Future? _gettingDataSocket;
 
-  /// Creates an FTP session with the provided file operations backend.
-  ///
-  /// [fileOperations] handles all file/directory logic (virtual, physical, or custom).
-  /// [serverType] determines the mode (read-only or read and write).
-  /// Optional parameters include [username], [password], and [logger].
-  ///
-  /// BREAKING CHANGE: `sharedDirectories` and `startingDirectory` are removed. All directory logic is now handled by the provided [fileOperations].
+  /// Callback invoked when this session's connection is closed.
+  /// Used by FtpServer to remove the session from its active list.
+  void Function()? onDisconnect;
+
   FtpSession(this.controlSocket,
       {this.username,
       this.password,
       required FileOperations fileOperations,
       required this.serverType,
-      required this.logger})
+      required this.logger,
+      this.onDisconnect})
       : fileOperations = fileOperations.copy(),
-        commandHandler = FTPCommandHandler(controlSocket, logger) {
+        commandHandler = FTPCommandHandler(logger) {
     sendResponse('220 Welcome to the FTP server');
     logger.generalLog('FtpSession created. Ready to process commands.');
     controlSocket.listen(
@@ -100,6 +98,7 @@ class FtpSession {
     dataSocket = null;
     dataListener = null;
     logger.generalLog('Connection closed');
+    onDisconnect?.call();
   }
 
   Future<bool> openDataConnection() async {
@@ -142,8 +141,6 @@ class FtpSession {
       var address = (await _getIpAddress()).replaceAll('.', ',');
       sendResponse('227 Entering Passive Mode ($address,$p1,$p2)');
 
-      /// assigning the future to make sure it finishes before running any other operation
-      /// check [openDataConnection]
       _gettingDataSocket =
           waitForClientDataSocket(timeout: Duration(seconds: 30));
     } catch (e) {
@@ -155,6 +152,10 @@ class FtpSession {
   Future<void> enterActiveMode(String parameters) async {
     try {
       List<String> parts = parameters.split(',');
+      if (parts.length < 6) {
+        sendResponse('501 Syntax error in PORT parameters');
+        return;
+      }
       String ip = parts.take(4).join('.');
       int port = int.parse(parts[4]) * 256 + int.parse(parts[5]);
       dataSocket = await Socket.connect(ip, port);
@@ -166,21 +167,39 @@ class FtpSession {
   }
 
   Future<String> _getIpAddress() async {
+    // Use the control socket's local address if available
+    try {
+      final addr = controlSocket.address;
+      if (addr.type == InternetAddressType.IPv4 &&
+          !addr.isLoopback &&
+          addr.address != '0.0.0.0') {
+        return addr.address;
+      }
+    } catch (_) {}
+
+    // Fallback: scan network interfaces for a private IPv4 address
     try {
       final networkInterfaces = await NetworkInterface.list();
       final ipList = networkInterfaces
           .map((interface) => interface.addresses)
           .expand((ip) => ip)
-          .where((ip) => ip.type == InternetAddressType.IPv4)
+          .where((ip) =>
+              ip.type == InternetAddressType.IPv4 &&
+              !ip.isLoopback &&
+              !ip.isLinkLocal)
           .toList();
 
-      // Filter IPs that start with '192'
-      final wifiIp = ipList.firstWhere(
-        (address) => address.address.startsWith('192'),
-        orElse: () => ipList.first,
-      );
-
-      return wifiIp.address;
+      if (ipList.isNotEmpty) {
+        // Prefer private network addresses
+        final privateIp = ipList.firstWhere(
+          (address) =>
+              address.address.startsWith('192.') ||
+              address.address.startsWith('10.') ||
+              address.address.startsWith('172.'),
+          orElse: () => ipList.first,
+        );
+        return privateIp.address;
+      }
     } catch (e) {
       logger.generalLog('Error getting IP address: $e');
     }
@@ -200,7 +219,7 @@ class FtpSession {
           'Listing directory: $path, for ${fileOperations.resolvePath(path)} dir contents: $dirContents');
 
       for (FileSystemEntity entity in dirContents) {
-        if (!transferInProgress) break; // Abort if transfer is cancelled
+        if (!transferInProgress) break;
 
         try {
           var stat = await entity.stat();
@@ -224,7 +243,6 @@ class FtpSession {
         } catch (entityError) {
           logger.generalLog(
               'Error processing entity during directory listing: $entityError');
-          // Continue with next entity
           continue;
         }
       }
@@ -303,7 +321,6 @@ class FtpSession {
     return DateFormat('MMM dd HH:mm').format(dateTime);
   }
 
-// Method to retrieve a file from the server
   Future<void> retrieveFile(String filename) async {
     if (!await openDataConnection()) {
       return;
@@ -313,7 +330,7 @@ class FtpSession {
       transferInProgress = true;
 
       if (!fileOperations.exists(filename)) {
-        sendResponse('550 File not found $filename');
+        sendResponse('550 File not found');
         transferInProgress = false;
         await _closeDataSocket();
         return;
@@ -324,7 +341,6 @@ class FtpSession {
       if (await file.exists()) {
         Stream<List<int>> fileStream = file.openRead();
 
-        // Handle potential socket errors during file transfer
         StreamSubscription<List<int>>? subscription;
         subscription = fileStream.listen(
           (data) {
@@ -369,7 +385,6 @@ class FtpSession {
     }
   }
 
-// Method to store a file on the server
   Future<void> storeFile(String filename) async {
     if (!await openDataConnection()) {
       return;
@@ -382,7 +397,6 @@ class FtpSession {
       String fullPath = fileOperations.resolvePath(filename);
       transferInProgress = true;
 
-      // Create the directory if it doesn't exist
       final directory = Directory(fullPath).parent;
       if (!await directory.exists()) {
         await directory.create(recursive: true);
@@ -391,7 +405,6 @@ class FtpSession {
       file = File(fullPath);
       fileSink = file.openWrite();
 
-      // Handle socket errors during file upload
       dataSocket!.listen(
         (data) {
           if (transferInProgress) {
@@ -436,7 +449,6 @@ class FtpSession {
     }
   }
 
-  // Helper method to handle transfer errors
   void _handleTransferError(IOSink? fileSink) async {
     sendResponse('426 Connection closed; transfer aborted');
     if (fileSink != null) {
@@ -504,7 +516,7 @@ class FtpSession {
       sendResponse(
           '250 Directory changed to ${fileOperations.currentDirectory}');
     } catch (e) {
-      sendResponse('550 Access denied or directory not found $e');
+      sendResponse('550 Access denied or directory not found');
       logger.generalLog('Error changing directory: $e');
     }
   }
@@ -515,37 +527,37 @@ class FtpSession {
       sendResponse(
           '250 Directory changed to ${fileOperations.currentDirectory}');
     } catch (e) {
-      sendResponse('550 Access denied or directory not found $e');
+      sendResponse('550 Access denied or directory not found');
       logger.generalLog('Error changing to parent directory: $e');
     }
   }
 
-  void makeDirectory(String dirname) async {
+  Future<void> makeDirectory(String dirname) async {
     try {
       await fileOperations.createDirectory(dirname);
       sendResponse('257 "$dirname" created');
     } catch (e) {
-      sendResponse('550 Failed to create directory, error: $e');
+      sendResponse('550 Failed to create directory');
       logger.generalLog('Error creating directory: $e');
     }
   }
 
-  void removeDirectory(String dirname) async {
+  Future<void> removeDirectory(String dirname) async {
     try {
       await fileOperations.deleteDirectory(dirname);
       sendResponse('250 Directory deleted');
     } catch (e) {
-      sendResponse('550 Failed to delete directory $e');
+      sendResponse('550 Failed to delete directory');
       logger.generalLog('Error deleting directory: $e');
     }
   }
 
-  void deleteFile(String filePath) async {
+  Future<void> deleteFile(String filePath) async {
     try {
       await fileOperations.deleteFile(filePath);
       sendResponse('250 File deleted');
     } catch (e) {
-      sendResponse('550 Failed to delete file $e');
+      sendResponse('550 Failed to delete file');
       logger.generalLog('Error deleting file: $e');
     }
   }
@@ -572,7 +584,6 @@ class FtpSession {
       int port = dataListener!.port;
       sendResponse('229 Entering Extended Passive Mode (|||$port|)');
 
-      // Properly wait for the client to connect and handle errors
       _gettingDataSocket =
           waitForClientDataSocket(timeout: Duration(seconds: 30));
     } catch (e) {
@@ -581,7 +592,7 @@ class FtpSession {
     }
   }
 
-  Future<void> handleMlsd(String argument, FtpSession session) async {
+  Future<void> handleMlsd(String argument) async {
     if (!await openDataConnection()) {
       return;
     }
@@ -608,7 +619,6 @@ class FtpSession {
         } catch (entityError) {
           logger
               .generalLog('Error processing entity during MLSD: $entityError');
-          // Continue with next entity
           continue;
         }
       }
@@ -623,13 +633,12 @@ class FtpSession {
       }
     } catch (e) {
       logger.generalLog('Error listing directory with MLSD: $e');
-      sendResponse('550 Failed to list directory: $e');
+      sendResponse('550 Failed to list directory');
       transferInProgress = false;
       await _closeDataSocket();
     }
   }
 
-// Method to abort a file transfer
   String _formatMlsdFacts(FileSystemEntity entity, FileStat stat) {
     String type = stat.type == FileSystemEntityType.directory ? "dir" : "file";
     String modify = DateFormat("yyyyMMddHHmmss")
@@ -640,7 +649,7 @@ class FtpSession {
     return "type=$type;modify=$modify;size=$size; $name\r\n";
   }
 
-  void handleMdtm(String argument, FtpSession session) {
+  void handleMdtm(String argument) {
     try {
       if (!fileOperations.exists(argument)) {
         sendResponse('550 File not found');
@@ -657,7 +666,7 @@ class FtpSession {
         sendResponse('550 File not found');
       }
     } catch (e) {
-      sendResponse('550 Could not get modification time: $e');
+      sendResponse('550 Could not get modification time');
       logger.generalLog('Error getting modification time: $e');
     }
   }
@@ -669,11 +678,11 @@ class FtpSession {
   Future<void> renameFileOrDirectory(String oldPath, String newPath) async {
     try {
       await fileOperations.renameFileOrDirectory(oldPath, newPath);
-      pendingRenameFrom = null; // Clear the pending state on success
+      pendingRenameFrom = null;
       sendResponse('250 Requested file action completed successfully');
     } catch (e) {
-      pendingRenameFrom = null; // Clear the pending state on error
-      sendResponse('550 Failed to rename: $e');
+      pendingRenameFrom = null;
+      sendResponse('550 Failed to rename');
       logger.generalLog('Error renaming $oldPath to $newPath: $e');
     }
   }

--- a/lib/ftp_session.dart
+++ b/lib/ftp_session.dart
@@ -67,9 +67,19 @@ class FtpSession {
         _commandQueue = _commandQueue.then((_) async {
           try {
             await commandHandler.handleCommand(trimmed, this);
+            // Flush after each command so the response is sent before the
+            // next command runs. Without this, microtask-chained responses
+            // can pile up in the socket buffer and confuse some FTP clients.
+            try {
+              await controlSocket.flush();
+            } catch (_) {
+              // Socket may already be closed (e.g. after QUIT)
+            }
           } catch (e, s) {
             logger.generalLog("error: $e stack: $s");
-            sendResponse('500 Internal server error');
+            try {
+              sendResponse('500 Internal server error');
+            } catch (_) {}
           }
         });
       }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: ftp_server
 description: "Dart FTP server: Read-only/read-write. Clients can list directories, get/put files, and perform standard FTP operations."
-version: 2.1.1
+version: 2.2.0
 homepage: https://github.com/abdelaziz-mahdy/ftp_server
 
 environment:

--- a/test/ftp_commands_test.dart
+++ b/test/ftp_commands_test.dart
@@ -52,8 +52,8 @@ class FtpTestClient {
       if (DateTime.now().isAfter(end)) {
         throw TimeoutException('Timeout. Buffer: ${_buffer.toString()}');
       }
-      await _dataReady.stream.first
-          .timeout(end.difference(DateTime.now()), onTimeout: () {
+      await _dataReady.stream.first.timeout(end.difference(DateTime.now()),
+          onTimeout: () {
         throw TimeoutException('Timeout. Buffer: ${_buffer.toString()}');
       });
     }
@@ -81,8 +81,8 @@ class FtpTestClient {
       if (DateTime.now().isAfter(end)) {
         throw TimeoutException('Timeout. Buffer: ${_buffer.toString()}');
       }
-      await _dataReady.stream.first
-          .timeout(end.difference(DateTime.now()), onTimeout: () {
+      await _dataReady.stream.first.timeout(end.difference(DateTime.now()),
+          onTimeout: () {
         throw TimeoutException('Timeout. Buffer: ${_buffer.toString()}');
       });
     }
@@ -122,8 +122,7 @@ void main() {
     File('${tempDir.path}/data.bin')
         .writeAsBytesSync(List.generate(100, (i) => i));
     Directory('${tempDir.path}/subdir').createSync();
-    File('${tempDir.path}/subdir/nested.txt')
-        .writeAsStringSync('Nested file');
+    File('${tempDir.path}/subdir/nested.txt').writeAsStringSync('Nested file');
 
     server = FtpServer(
       port,

--- a/test/ftp_commands_test.dart
+++ b/test/ftp_commands_test.dart
@@ -1,0 +1,596 @@
+// ignore_for_file: avoid_print
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+import 'package:ftp_server/file_operations/virtual_file_operations.dart';
+import 'package:ftp_server/ftp_server.dart';
+import 'package:ftp_server/server_type.dart';
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+/// Helper to send a command and read the response from the FTP server.
+class FtpTestClient {
+  final Socket _socket;
+  final StringBuffer _buffer = StringBuffer();
+  final StreamController<void> _dataReady = StreamController<void>.broadcast();
+  late StreamSubscription _sub;
+
+  FtpTestClient._(this._socket) {
+    _sub = _socket.listen((data) {
+      _buffer.write(utf8.decode(data));
+      _dataReady.add(null);
+    }, onDone: () {
+      _dataReady.close();
+    });
+  }
+
+  static Future<FtpTestClient> connect(int port) async {
+    final socket = await Socket.connect('127.0.0.1', port);
+    final client = FtpTestClient._(socket);
+    await client.readResponse(); // consume 220 welcome
+    return client;
+  }
+
+  Future<String> readResponse({Duration? timeout}) async {
+    final deadline = timeout ?? const Duration(seconds: 5);
+    final end = DateTime.now().add(deadline);
+
+    while (true) {
+      final content = _buffer.toString();
+      final lines = content.split('\r\n');
+      for (int i = 0; i < lines.length; i++) {
+        final line = lines[i];
+        if (line.isNotEmpty && RegExp(r'^\d{3}[ ]').hasMatch(line)) {
+          final consumed = '${lines.sublist(0, i + 1).join('\r\n')}\r\n';
+          final remaining = content.substring(consumed.length);
+          _buffer.clear();
+          _buffer.write(remaining);
+          return line.trim();
+        }
+      }
+      if (DateTime.now().isAfter(end)) {
+        throw TimeoutException('Timeout. Buffer: ${_buffer.toString()}');
+      }
+      await _dataReady.stream.first
+          .timeout(end.difference(DateTime.now()), onTimeout: () {
+        throw TimeoutException('Timeout. Buffer: ${_buffer.toString()}');
+      });
+    }
+  }
+
+  Future<String> readMultiLineResponse({Duration? timeout}) async {
+    final deadline = timeout ?? const Duration(seconds: 5);
+    final end = DateTime.now().add(deadline);
+
+    while (true) {
+      final content = _buffer.toString();
+      final lines = content.split('\r\n');
+      bool foundStart = false;
+      for (int i = 0; i < lines.length; i++) {
+        final line = lines[i];
+        if (!foundStart && RegExp(r'^\d{3}-').hasMatch(line)) foundStart = true;
+        if (foundStart && RegExp(r'^\d{3} ').hasMatch(line)) {
+          final consumed = '${lines.sublist(0, i + 1).join('\r\n')}\r\n';
+          final remaining = content.substring(consumed.length);
+          _buffer.clear();
+          _buffer.write(remaining);
+          return lines.sublist(0, i + 1).join('\r\n').trim();
+        }
+      }
+      if (DateTime.now().isAfter(end)) {
+        throw TimeoutException('Timeout. Buffer: ${_buffer.toString()}');
+      }
+      await _dataReady.stream.first
+          .timeout(end.difference(DateTime.now()), onTimeout: () {
+        throw TimeoutException('Timeout. Buffer: ${_buffer.toString()}');
+      });
+    }
+  }
+
+  void send(String command) {
+    _socket.write('$command\r\n');
+  }
+
+  Future<String> command(String cmd) async {
+    send(cmd);
+    return readResponse();
+  }
+
+  Future<void> login(
+      [String user = 'testuser', String pass = 'testpass']) async {
+    send('USER $user');
+    await readResponse();
+    send('PASS $pass');
+    await readResponse();
+  }
+
+  Future<void> close() async {
+    await _sub.cancel();
+    await _socket.close();
+  }
+}
+
+void main() {
+  late FtpServer server;
+  late Directory tempDir;
+  const int port = 2250;
+
+  setUpAll(() async {
+    tempDir = Directory.systemTemp.createTempSync('ftp_cmd_test_');
+    File('${tempDir.path}/hello.txt').writeAsStringSync('Hello!');
+    File('${tempDir.path}/data.bin')
+        .writeAsBytesSync(List.generate(100, (i) => i));
+    Directory('${tempDir.path}/subdir').createSync();
+    File('${tempDir.path}/subdir/nested.txt')
+        .writeAsStringSync('Nested file');
+
+    server = FtpServer(
+      port,
+      username: 'testuser',
+      password: 'testpass',
+      fileOperations: VirtualFileOperations([tempDir.path],
+          startingDirectory: p.basename(tempDir.path)),
+      serverType: ServerType.readAndWrite,
+      logFunction: (msg) {},
+    );
+    await server.startInBackground();
+  });
+
+  tearDownAll(() async {
+    await server.stop();
+    tempDir.deleteSync(recursive: true);
+  });
+
+  group('Authentication', () {
+    test('USER with empty argument returns 501', () async {
+      final c = await FtpTestClient.connect(port);
+      final r = await c.command('USER');
+      expect(r, startsWith('501'));
+      await c.close();
+    });
+
+    test('PASS before USER returns 503', () async {
+      final c = await FtpTestClient.connect(port);
+      final r = await c.command('PASS testpass');
+      expect(r, startsWith('503'));
+      await c.close();
+    });
+
+    test('Commands require auth when credentials configured', () async {
+      final c = await FtpTestClient.connect(port);
+      final r = await c.command('LIST');
+      expect(r, startsWith('530'));
+      await c.close();
+    });
+
+    test('Pre-auth commands work without login', () async {
+      final c = await FtpTestClient.connect(port);
+      expect(await c.command('SYST'), startsWith('215'));
+      expect(await c.command('NOOP'), startsWith('200'));
+
+      c.send('FEAT');
+      final feat = await c.readMultiLineResponse();
+      expect(feat, startsWith('211'));
+
+      expect(await c.command('OPTS UTF8 ON'), startsWith('200'));
+      await c.close();
+    });
+
+    test('Successful login', () async {
+      final c = await FtpTestClient.connect(port);
+      expect(await c.command('USER testuser'), startsWith('331'));
+      expect(await c.command('PASS testpass'), startsWith('230'));
+      await c.close();
+    });
+
+    test('Wrong password returns 530', () async {
+      final c = await FtpTestClient.connect(port);
+      await c.command('USER testuser');
+      expect(await c.command('PASS wrong'), startsWith('530'));
+      await c.close();
+    });
+  });
+
+  group('Directory commands', () {
+    test('PWD returns current directory', () async {
+      final c = await FtpTestClient.connect(port);
+      await c.login();
+      final r = await c.command('PWD');
+      expect(r, startsWith('257'));
+      expect(r, contains('"'));
+      await c.close();
+    });
+
+    test('XPWD works same as PWD', () async {
+      final c = await FtpTestClient.connect(port);
+      await c.login();
+      final r = await c.command('XPWD');
+      expect(r, startsWith('257'));
+      await c.close();
+    });
+
+    test('CWD to valid directory', () async {
+      final c = await FtpTestClient.connect(port);
+      await c.login();
+      final r = await c.command('CWD subdir');
+      expect(r, startsWith('250'));
+      await c.close();
+    });
+
+    test('CWD to invalid directory returns 550', () async {
+      final c = await FtpTestClient.connect(port);
+      await c.login();
+      final r = await c.command('CWD nonexistent');
+      expect(r, startsWith('550'));
+      // Verify no internal path leaked
+      expect(r, isNot(contains(tempDir.path)));
+      await c.close();
+    });
+
+    test('CDUP from subdirectory', () async {
+      final c = await FtpTestClient.connect(port);
+      await c.login();
+      await c.command('CWD subdir');
+      final r = await c.command('CDUP');
+      expect(r, startsWith('250'));
+      await c.close();
+    });
+
+    test('MKD creates directory', () async {
+      final c = await FtpTestClient.connect(port);
+      await c.login();
+      final r = await c.command('MKD newdir');
+      expect(r, startsWith('257'));
+      // Clean up
+      await c.command('RMD newdir');
+      await c.close();
+    });
+
+    test('RMD removes directory', () async {
+      final c = await FtpTestClient.connect(port);
+      await c.login();
+      await c.command('MKD toremove');
+      final r = await c.command('RMD toremove');
+      expect(r, startsWith('250'));
+      await c.close();
+    });
+  });
+
+  group('TYPE command', () {
+    test('TYPE A accepted', () async {
+      final c = await FtpTestClient.connect(port);
+      await c.login();
+      expect(await c.command('TYPE A'), startsWith('200'));
+      await c.close();
+    });
+
+    test('TYPE I accepted', () async {
+      final c = await FtpTestClient.connect(port);
+      await c.login();
+      expect(await c.command('TYPE I'), startsWith('200'));
+      await c.close();
+    });
+
+    test('TYPE A N accepted (ASCII Non-print)', () async {
+      final c = await FtpTestClient.connect(port);
+      await c.login();
+      expect(await c.command('TYPE A N'), startsWith('200'));
+      await c.close();
+    });
+
+    test('TYPE X rejected', () async {
+      final c = await FtpTestClient.connect(port);
+      await c.login();
+      expect(await c.command('TYPE X'), startsWith('504'));
+      await c.close();
+    });
+
+    test('TYPE with no argument returns 501', () async {
+      final c = await FtpTestClient.connect(port);
+      await c.login();
+      expect(await c.command('TYPE'), startsWith('501'));
+      await c.close();
+    });
+  });
+
+  group('STRU/MODE/ALLO', () {
+    test('STRU F accepted', () async {
+      final c = await FtpTestClient.connect(port);
+      await c.login();
+      expect(await c.command('STRU F'), startsWith('200'));
+      await c.close();
+    });
+
+    test('STRU R rejected', () async {
+      final c = await FtpTestClient.connect(port);
+      await c.login();
+      expect(await c.command('STRU R'), startsWith('504'));
+      await c.close();
+    });
+
+    test('STRU with no argument returns 501', () async {
+      final c = await FtpTestClient.connect(port);
+      await c.login();
+      expect(await c.command('STRU'), startsWith('501'));
+      await c.close();
+    });
+
+    test('MODE S accepted', () async {
+      final c = await FtpTestClient.connect(port);
+      await c.login();
+      expect(await c.command('MODE S'), startsWith('200'));
+      await c.close();
+    });
+
+    test('MODE B rejected', () async {
+      final c = await FtpTestClient.connect(port);
+      await c.login();
+      expect(await c.command('MODE B'), startsWith('504'));
+      await c.close();
+    });
+
+    test('MODE with no argument returns 501', () async {
+      final c = await FtpTestClient.connect(port);
+      await c.login();
+      expect(await c.command('MODE'), startsWith('501'));
+      await c.close();
+    });
+
+    test('ALLO returns 202', () async {
+      final c = await FtpTestClient.connect(port);
+      await c.login();
+      expect(await c.command('ALLO 1024'), startsWith('202'));
+      await c.close();
+    });
+  });
+
+  group('OPTS', () {
+    test('OPTS UTF8 ON', () async {
+      final c = await FtpTestClient.connect(port);
+      final r = await c.command('OPTS UTF8 ON');
+      expect(r, startsWith('200'));
+      expect(r, contains('enable'));
+      await c.close();
+    });
+
+    test('OPTS UTF8 OFF', () async {
+      final c = await FtpTestClient.connect(port);
+      final r = await c.command('OPTS UTF8 OFF');
+      expect(r, startsWith('200'));
+      expect(r, contains('disable'));
+      await c.close();
+    });
+
+    test('OPTS UTF8 without ON/OFF returns 501', () async {
+      final c = await FtpTestClient.connect(port);
+      final r = await c.command('OPTS UTF8');
+      expect(r, startsWith('501'));
+      await c.close();
+    });
+
+    test('OPTS with no argument returns 501', () async {
+      final c = await FtpTestClient.connect(port);
+      final r = await c.command('OPTS');
+      expect(r, startsWith('501'));
+      await c.close();
+    });
+
+    test('OPTS UNKNOWN returns 502', () async {
+      final c = await FtpTestClient.connect(port);
+      final r = await c.command('OPTS SOMETHING ON');
+      expect(r, startsWith('502'));
+      await c.close();
+    });
+  });
+
+  group('FEAT', () {
+    test('FEAT lists supported features', () async {
+      final c = await FtpTestClient.connect(port);
+      c.send('FEAT');
+      final r = await c.readMultiLineResponse();
+      expect(r, contains('SIZE'));
+      expect(r, contains('MDTM'));
+      expect(r, contains('MLSD'));
+      expect(r, contains('EPSV'));
+      expect(r, contains('PASV'));
+      expect(r, contains('UTF8'));
+      expect(r, startsWith('211'));
+      await c.close();
+    });
+  });
+
+  group('EPSV', () {
+    test('EPSV enters extended passive mode', () async {
+      final c = await FtpTestClient.connect(port);
+      await c.login();
+      final r = await c.command('EPSV');
+      expect(r, startsWith('229'));
+      expect(r, contains('|||'));
+      // Connect to the passive port to prevent timeout error on server
+      final portMatch = RegExp(r'\|\|\|(\d+)\|').firstMatch(r);
+      if (portMatch != null) {
+        final dataPort = int.parse(portMatch.group(1)!);
+        final dataSocket = await Socket.connect('127.0.0.1', dataPort);
+        await dataSocket.close();
+      }
+      await c.close();
+    });
+
+    test('EPSV ALL returns 200', () async {
+      final c = await FtpTestClient.connect(port);
+      await c.login();
+      final r = await c.command('EPSV ALL');
+      expect(r, startsWith('200'));
+      await c.close();
+    });
+  });
+
+  group('HELP', () {
+    test('HELP returns command list', () async {
+      final c = await FtpTestClient.connect(port);
+      await c.login();
+      c.send('HELP');
+      final r = await c.readMultiLineResponse();
+      expect(r, startsWith('214'));
+      expect(r, contains('USER'));
+      expect(r, contains('RETR'));
+      expect(r, contains('STOR'));
+      await c.close();
+    });
+  });
+
+  group('STAT/SITE/ACCT/REIN', () {
+    test('STAT returns server status', () async {
+      final c = await FtpTestClient.connect(port);
+      await c.login();
+      expect(await c.command('STAT'), startsWith('211'));
+      await c.close();
+    });
+
+    test('SITE returns 502', () async {
+      final c = await FtpTestClient.connect(port);
+      await c.login();
+      expect(await c.command('SITE CHMOD 755 file'), startsWith('502'));
+      await c.close();
+    });
+
+    test('ACCT returns 202', () async {
+      final c = await FtpTestClient.connect(port);
+      await c.login();
+      expect(await c.command('ACCT info'), startsWith('202'));
+      await c.close();
+    });
+
+    test('REIN resets authentication', () async {
+      final c = await FtpTestClient.connect(port);
+      await c.login();
+      expect(await c.command('REIN'), startsWith('220'));
+      // After REIN, commands should require auth
+      expect(await c.command('PWD'), startsWith('530'));
+      await c.close();
+    });
+  });
+
+  group('Unknown commands', () {
+    test('Unknown command returns 502', () async {
+      final c = await FtpTestClient.connect(port);
+      await c.login();
+      final r = await c.command('BOGUS');
+      expect(r, startsWith('502'));
+      // Should not echo the command back
+      expect(r, isNot(contains('BOGUS')));
+      await c.close();
+    });
+  });
+
+  group('SIZE/MDTM', () {
+    test('SIZE returns file size', () async {
+      final c = await FtpTestClient.connect(port);
+      await c.login();
+      final r = await c.command('SIZE hello.txt');
+      expect(r, startsWith('213'));
+      expect(r, contains('6')); // "Hello!" is 6 bytes
+      await c.close();
+    });
+
+    test('SIZE of nonexistent file returns 550', () async {
+      final c = await FtpTestClient.connect(port);
+      await c.login();
+      expect(await c.command('SIZE nope.txt'), startsWith('550'));
+      await c.close();
+    });
+
+    test('MDTM returns modification time', () async {
+      final c = await FtpTestClient.connect(port);
+      await c.login();
+      final r = await c.command('MDTM hello.txt');
+      expect(r, startsWith('213'));
+      // Should be in YYYYMMDDHHmmss format (14 digits)
+      expect(RegExp(r'213 \d{14}').hasMatch(r), isTrue);
+      await c.close();
+    });
+  });
+
+  group('QUIT', () {
+    test('QUIT returns 221', () async {
+      final c = await FtpTestClient.connect(port);
+      final r = await c.command('QUIT');
+      expect(r, startsWith('221'));
+      await c.close();
+    });
+  });
+
+  group('SYST', () {
+    test('SYST returns UNIX Type', () async {
+      final c = await FtpTestClient.connect(port);
+      final r = await c.command('SYST');
+      expect(r, startsWith('215'));
+      expect(r, contains('UNIX'));
+      await c.close();
+    });
+  });
+
+  group('Error message sanitization', () {
+    test('CWD error does not leak server paths', () async {
+      final c = await FtpTestClient.connect(port);
+      await c.login();
+      final r = await c.command('CWD /etc/passwd');
+      expect(r, startsWith('550'));
+      expect(r, isNot(contains('/var')));
+      expect(r, isNot(contains('/tmp')));
+      expect(r, isNot(contains('Exception')));
+      await c.close();
+    });
+
+    test('MKD error does not leak server paths', () async {
+      final c = await FtpTestClient.connect(port);
+      await c.login();
+      // Try to create a directory at root of virtual FS (should fail for virtual ops)
+      final r = await c.command('DELE /etc/passwd');
+      expect(r, isNot(contains('/var')));
+      expect(r, isNot(contains('/tmp')));
+      await c.close();
+    });
+  });
+
+  group('Session management', () {
+    test('Sessions are removed from active list on disconnect', () async {
+      final initialCount = server.activeSessions.length;
+      final c = await FtpTestClient.connect(port);
+      await Future.delayed(Duration(milliseconds: 100));
+      expect(server.activeSessions.length, greaterThan(initialCount));
+
+      await c.command('QUIT');
+      await c.close();
+      await Future.delayed(Duration(milliseconds: 200));
+      expect(server.activeSessions.length, equals(initialCount));
+    });
+  });
+
+  group('Pipelined commands', () {
+    test('Multiple commands in one TCP segment are handled', () async {
+      final socket = await Socket.connect('127.0.0.1', port);
+      final buffer = StringBuffer();
+      final dataReady = StreamController<void>.broadcast();
+      socket.listen((data) {
+        buffer.write(utf8.decode(data));
+        dataReady.add(null);
+      });
+      // Wait for 220
+      await dataReady.stream.first.timeout(Duration(seconds: 2));
+      buffer.clear();
+
+      // Send two pre-auth commands in one write
+      socket.write('SYST\r\nNOOP\r\n');
+      // Wait for responses
+      await Future.delayed(Duration(milliseconds: 500));
+
+      final response = buffer.toString();
+      expect(response, contains('215'));
+      expect(response, contains('200'));
+      dataReady.close();
+      await socket.close();
+    });
+  });
+}

--- a/test/ftp_server_test.dart
+++ b/test/ftp_server_test.dart
@@ -21,10 +21,9 @@ void main() {
   final Directory clientTempDir =
       Directory.systemTemp.createTempSync('ftp_test0');
 
-  Future<String> execFTPCmdOnWin(String commands) async {
+  Future<String> execFTPCmdOnWin(String commands,
+      {String user = 'test', String password = 'password'}) async {
     const String ftpHost = '127.0.0.1 $port';
-    const String user = 'test';
-    const String password = 'password';
 
     String fullCommands = '''
     open $ftpHost
@@ -172,7 +171,7 @@ void main() {
 
       var output = await readAllOutput(logFilePath);
       if (Platform.isWindows) {
-        output = await execFTPCmdOnWin("cd ..\n ls");
+        output = await execFTPCmdOnWin("cd ..\ndir");
       }
 
       String listing = await outputHandler.generateDirectoryListing(
@@ -807,7 +806,7 @@ void main() {
         var output = await readAllOutput(logFilePath);
         if (Platform.isWindows) {
           output = await execFTPCmdOnWin(
-              "cd ${basename(sharedDirectories.first)}\n ls");
+              "cd ${basename(sharedDirectories.first)}\ndir");
         }
 
         String listing = await outputHandler.generateDirectoryListing(
@@ -838,7 +837,7 @@ void main() {
 
         var output = await readAllOutput(logFilePath);
         if (Platform.isWindows) {
-          output = await execFTPCmdOnWin("cd /\n ls");
+          output = await execFTPCmdOnWin("cd /\ndir");
         }
 
         String listing = await outputHandler.generateDirectoryListing(
@@ -873,7 +872,7 @@ void main() {
         if (Platform.isWindows) {
           // Ensure we are in the correct starting directory before using relative path
           output = await execFTPCmdOnWin(
-              "cd ${basename(sharedDirectories.first)}\nls test_dir");
+              "cd ${basename(sharedDirectories.first)}\ndir test_dir");
         }
 
         // Create VFS instance with the correct starting directory for generating expected output
@@ -919,7 +918,7 @@ void main() {
         var output = await readAllOutput(logFilePath);
         if (Platform.isWindows) {
           output = await execFTPCmdOnWin(
-              "cd ${basename(sharedDirectories.first)}\n ls test_dir");
+              "cd ${basename(sharedDirectories.first)}\ndir test_dir");
         }
 
         String listing = await outputHandler.generateDirectoryListing(
@@ -1243,9 +1242,6 @@ void main() {
       try {
         await server.stop();
       } catch (_) {}
-      try {
-        ftpClient.kill();
-      } catch (_) {}
     });
 
     test(
@@ -1261,16 +1257,17 @@ void main() {
         logFunction: (String message) => print(message),
       );
       await server.startInBackground();
-      // Create a test client that stays connected (don't use execFTPCmdOnWin which quits)
-      ftpClient = await Process.start(
-        Platform.isWindows ? 'ftp' : 'bash',
-        Platform.isWindows ? ['-n', '-v'] : ['-c', 'ftp -n -v'],
-        runInShell: true,
-      );
-      // Authenticate the test client (keeps connection open)
-      await connectAndAuthenticate(ftpClient, logFilePath);
-      await Future.delayed(
-          const Duration(milliseconds: 500)); // Wait for log to be written
+      // Use a raw socket to keep the connection alive reliably on all platforms
+      final socket = await Socket.connect('127.0.0.1', port);
+      // Read the 220 welcome message
+      await Future.delayed(const Duration(milliseconds: 300));
+      // Authenticate
+      socket.write('USER test\r\n');
+      await socket.flush();
+      await Future.delayed(const Duration(milliseconds: 200));
+      socket.write('PASS password\r\n');
+      await socket.flush();
+      await Future.delayed(const Duration(milliseconds: 500));
       // Ensure there's an active session
       expect(server.activeSessions.isNotEmpty, isTrue,
           reason: 'No active sessions found after client connected');
@@ -1280,6 +1277,8 @@ void main() {
       // Verify that all active sessions are terminated
       expect(server.activeSessions.isEmpty, isTrue,
           reason: 'Active sessions list is not cleared after server stop');
+      // Clean up the socket
+      socket.destroy();
     });
   });
 
@@ -1362,7 +1361,9 @@ void main() {
       var output = await readAllOutput(logFilePath);
       if (Platform.isWindows) {
         output = await execFTPCmdOnWin(
-            "pwd\ncd 2025-04-27/ILCE-7M3_4529168/133119/\ncd /\ncd 2025-04-27\nmkdir 2025-04-27\ncd 2025-04-27");
+            "pwd\ncd 2025-04-27/ILCE-7M3_4529168/133119/\ncd /\ncd 2025-04-27\nmkdir 2025-04-27\ncd 2025-04-27",
+            user: 'yxz',
+            password: '123456');
       }
 
       // Verify initial CWD attempts fail because the directory doesn't exist physically
@@ -1408,7 +1409,9 @@ void main() {
       var output = await readAllOutput(logFilePath);
       if (Platform.isWindows) {
         output = await execFTPCmdOnWin(
-            "cd /photos\npwd\nls\ncd 2023-albums\npwd\nls");
+            "cd /photos\npwd\ndir\ncd 2023-albums\npwd\ndir",
+            user: 'yxz',
+            password: '123456');
       }
 
       // Use outputHandler for expected CD outputs
@@ -1441,7 +1444,9 @@ void main() {
       var output = await readAllOutput(logFilePath);
       if (Platform.isWindows) {
         output = await execFTPCmdOnWin(
-            "cd /\nmkdir $dir1\ncd $dir1\nmkdir $dir2\nls");
+            "cd /\nmkdir $dir1\ncd $dir1\nmkdir $dir2\ndir",
+            user: 'yxz',
+            password: '123456');
       }
 
       // Use outputHandler for expected outputs

--- a/test/ftp_server_test.dart
+++ b/test/ftp_server_test.dart
@@ -1239,6 +1239,15 @@ void main() {
   });
 
   group('Server termination', () {
+    tearDown(() async {
+      try {
+        await server.stop();
+      } catch (_) {}
+      try {
+        ftpClient.kill();
+      } catch (_) {}
+    });
+
     test(
         'Close method terminates active sessions and clears activeSessions list',
         () async {
@@ -1252,18 +1261,14 @@ void main() {
         logFunction: (String message) => print(message),
       );
       await server.startInBackground();
-      // Create a test client and connect to the server
+      // Create a test client that stays connected (don't use execFTPCmdOnWin which quits)
       ftpClient = await Process.start(
         Platform.isWindows ? 'ftp' : 'bash',
         Platform.isWindows ? ['-n', '-v'] : ['-c', 'ftp -n -v'],
         runInShell: true,
       );
-      if (Platform.isWindows) {
-        await execFTPCmdOnWin('pwd');
-      } else {
-        // Authenticate the test client
-        await connectAndAuthenticate(ftpClient, logFilePath);
-      }
+      // Authenticate the test client (keeps connection open)
+      await connectAndAuthenticate(ftpClient, logFilePath);
       await Future.delayed(
           const Duration(milliseconds: 500)); // Wait for log to be written
       // Ensure there's an active session


### PR DESCRIPTION
## Summary

Fixes #15 and delivers a comprehensive RFC compliance overhaul based on a full review against RFC 959, RFC 2389, RFC 2428, and RFC 3659.

### Connection error fixes (Issue #15)
- Add `onError` handler to control socket listener — prevents unhandled `SocketException: Connection reset by peer` (errno 54)
- Wrap `closeConnection()` socket operations in try/catch — prevents crashes when closing already-closed sockets
- Clean up data listener in `abortTransfer()` — prevents orphaned server sockets
- Handle `EPSV ALL` command properly (200 response)

### Security fixes
- **Authentication enforcement**: Commands now require login when credentials are configured. Previously, any client could skip USER/PASS and directly use LIST, RETR, STOR, etc.
- **Path leakage**: Error responses no longer expose server filesystem paths or exception details

### Async correctness
- `handleCommand` is now `async` — all session methods (MKD, RMD, DELE, RNTO, RENAME, STOR, RETR, etc.) are properly `await`ed instead of fire-and-forget
- Fixed `handleRnto` rethrowing exceptions without sending a response

### Session management
- Sessions auto-remove from `activeSessions` via `onDisconnect` callback — fixes unbounded memory leak
- `activeSessions` returns unmodifiable list

### Network address fix
- `_getIpAddress` now uses `controlSocket.address` first, then falls back to scanning for private IPs across 192.x, 10.x, and 172.x networks (was hardcoded to 192 only)

### RFC compliance improvements

**LIST/NLST:**
- LIST strips `-la`/`-a`/`-l` flags that clients like FileZilla send (was treating them as paths)
- NLST separated from LIST — returns bare filenames per RFC 959

**Command pipelining:**
- Multiple commands in one TCP segment are now processed independently (was silently dropping all but the first)

**New commands:** NLST, HELP, STAT, STRU, MODE, ALLO, ACCT, REIN, SITE

**Improved validation:**
- USER: validates non-empty argument (501)
- PASS: validates USER was called first (503)
- TYPE: accepts `TYPE A N` form, validates empty args
- STRU/MODE: validates empty args (501)
- OPTS: validates empty args, fixes crash on `OPTS UTF8` without ON/OFF
- ABOR: sends 426 + 226 per RFC 959 section 5.4
- FEAT: advertises MLSD capability
- Default 502 no longer echoes command/arguments (information leak)
- Passive socket leak: old `dataListener` closed before creating new one on repeated PASV/EPSV

### Internal API changes
- `FTPCommandHandler` constructor no longer takes `controlSocket` (was unused — all communication goes through the session)
- `handleCommand` is now `async` (`Future<void>`)
- `handleMlsd`/`handleMdtm` signatures simplified

## Test plan
- [x] All 115 existing tests pass
- [x] 48 new command-level tests (`test/ftp_commands_test.dart`) covering:
  - Authentication enforcement (USER, PASS, pre-auth commands, 530 rejection)
  - Directory commands (PWD, XPWD, CWD, CDUP, MKD, RMD)
  - TYPE (A, I, A N, invalid, empty)
  - STRU/MODE/ALLO (valid, invalid, empty args)
  - OPTS (UTF8 ON/OFF, empty, invalid)
  - FEAT, EPSV, EPSV ALL, HELP, STAT, SITE, ACCT, REIN
  - SIZE, MDTM, SYST, QUIT, NOOP
  - Unknown commands (502 without echo)
  - Error message sanitization (no path leakage)
  - Session cleanup on disconnect
  - Pipelined commands in one TCP segment
- [x] `dart analyze` clean

**Total: 163 tests passing**