### PR TITLE
Implement REIN, ALLO, ACCT, SITE commands per RFC 959

### DIFF
--- a/lib/ftp_command_handler.dart
+++ b/lib/ftp_command_handler.dart
@@ -7,7 +7,7 @@ class FTPCommandHandler {
 
   FTPCommandHandler(this.logger);
 
-  /// Commands that are allowed before authentication
+  /// Commands that are allowed before authentication (RFC 959)
   static const _preAuthCommands = {
     'USER',
     'PASS',
@@ -16,6 +16,8 @@ class FTPCommandHandler {
     'SYST',
     'NOOP',
     'OPTS',
+    'REIN',
+    'ACCT',
   };
 
   Future<void> handleCommand(String commandLine, FtpSession session) async {
@@ -144,7 +146,7 @@ class FTPCommandHandler {
         handleMode(argument, session);
         break;
       case 'ALLO':
-        session.sendResponse('202 ALLO command not needed');
+        handleAllo(argument, session);
         break;
       case 'STAT':
         session.sendResponse('211 Server is running');
@@ -153,15 +155,13 @@ class FTPCommandHandler {
         handleHelp(session);
         break;
       case 'SITE':
-        session.sendResponse('502 SITE command not implemented');
+        handleSite(argument, session);
         break;
       case 'ACCT':
-        session.sendResponse('202 ACCT command not needed');
+        handleAcct(argument, session);
         break;
       case 'REIN':
-        session.isAuthenticated = false;
-        session.cachedUsername = null;
-        session.sendResponse('220 Service ready for new user');
+        handleRein(session);
         break;
       default:
         session.sendResponse('502 Command not implemented');
@@ -355,11 +355,72 @@ class FTPCommandHandler {
     }
   }
 
+  /// ALLO: Reserve storage space (RFC 959).
+  /// This server does not require pre-allocation, so the command is accepted
+  /// as a no-op. The argument (byte count) is validated for correct syntax.
+  /// Optional second argument form: `ALLO <bytes> R <record-size>`
+  void handleAllo(String argument, FtpSession session) {
+    if (argument.isEmpty) {
+      session.sendResponse('501 Syntax error in parameters');
+      return;
+    }
+    // Parse: <decimal-bytes> [SP R SP <decimal-record-size>]
+    final parts = argument.split(RegExp(r'\s+'));
+    final bytes = int.tryParse(parts[0]);
+    if (bytes == null || bytes < 0) {
+      session.sendResponse('501 Syntax error in parameters');
+      return;
+    }
+    if (parts.length > 1) {
+      if (parts.length != 3 ||
+          parts[1].toUpperCase() != 'R' ||
+          int.tryParse(parts[2]) == null) {
+        session.sendResponse('501 Syntax error in parameters');
+        return;
+      }
+    }
+    session.sendResponse('200 ALLO command OK (no storage allocation needed)');
+  }
+
+  /// ACCT: Provide account information (RFC 959).
+  /// This server does not use accounts, so the command is accepted as
+  /// superfluous. The argument is validated for non-empty syntax.
+  void handleAcct(String argument, FtpSession session) {
+    if (argument.isEmpty) {
+      session.sendResponse('501 Syntax error in parameters');
+      return;
+    }
+    // This server does not require account information
+    session.sendResponse('202 ACCT command superfluous');
+  }
+
+  /// REIN: Reinitialize session (RFC 959).
+  /// Flushes all user/account information and transfer parameters.
+  /// Any transfer in progress is allowed to complete.
+  /// The control connection remains open for a new USER command.
+  void handleRein(FtpSession session) {
+    session.reinitialize();
+    session.sendResponse('220 Service ready for new user');
+  }
+
+  /// SITE: Execute site-specific commands (RFC 959).
+  /// This server does not implement any site-specific commands.
+  void handleSite(String argument, FtpSession session) {
+    if (argument.isEmpty) {
+      session.sendResponse('501 Syntax error in parameters');
+      return;
+    }
+    // No site-specific commands are implemented
+    session.sendResponse('502 SITE command not implemented');
+  }
+
   void handleHelp(FtpSession session) {
     session.sendResponse('214-The following commands are supported:');
-    session.sendResponse(' USER PASS QUIT PASV PORT EPSV LIST NLST RETR STOR');
-    session.sendResponse(' CWD CDUP MKD RMD DELE PWD TYPE SIZE FEAT OPTS SYST');
-    session.sendResponse(' NOOP ABOR MLSD MDTM RNFR RNTO STRU MODE ALLO HELP');
+    session.sendResponse(' USER PASS ACCT QUIT REIN PASV PORT EPSV');
+    session.sendResponse(' LIST NLST RETR STOR CWD CDUP MKD RMD DELE');
+    session.sendResponse(' PWD TYPE SIZE FEAT OPTS SYST NOOP ABOR');
+    session.sendResponse(' MLSD MDTM RNFR RNTO STRU MODE ALLO STAT');
+    session.sendResponse(' SITE HELP');
     session.sendResponse('214 End');
   }
 }

--- a/lib/ftp_session.dart
+++ b/lib/ftp_session.dart
@@ -92,6 +92,35 @@ class FtpSession {
     }
   }
 
+  /// Reinitialize the session to its initial state (RFC 959 REIN).
+  /// Resets authentication, transfer parameters, data connections, and
+  /// working directory. If a transfer is in progress, data connections
+  /// are left open until the transfer completes naturally.
+  void reinitialize() {
+    isAuthenticated = false;
+    cachedUsername = null;
+    pendingRenameFrom = null;
+
+    // Reset working directory to root
+    fileOperations.currentDirectory = fileOperations.rootDirectory;
+
+    if (!transferInProgress) {
+      // Only close data connections if no transfer is active.
+      // RFC 959: "allow any transfer in progress to be completed"
+      try {
+        dataSocket?.close();
+      } catch (_) {}
+      try {
+        dataListener?.close();
+      } catch (_) {}
+      dataSocket = null;
+      dataListener = null;
+      _gettingDataSocket = null;
+    }
+    // If a transfer IS in progress, data connections remain open.
+    // They will be cleaned up when the transfer completes.
+  }
+
   void sendResponse(String message) {
     logger.logResponse(message);
     try {

--- a/test/ftp_commands_test.dart
+++ b/test/ftp_commands_test.dart
@@ -336,10 +336,10 @@ void main() {
       await c.close();
     });
 
-    test('ALLO returns 202', () async {
+    test('ALLO with argument returns 200', () async {
       final c = await FtpTestClient.connect(port);
       await c.login();
-      expect(await c.command('ALLO 1024'), startsWith('202'));
+      expect(await c.command('ALLO 1024'), startsWith('200'));
       await c.close();
     });
   });
@@ -439,34 +439,200 @@ void main() {
     });
   });
 
-  group('STAT/SITE/ACCT/REIN', () {
+  group('STAT', () {
     test('STAT returns server status', () async {
       final c = await FtpTestClient.connect(port);
       await c.login();
       expect(await c.command('STAT'), startsWith('211'));
       await c.close();
     });
+  });
 
-    test('SITE returns 502', () async {
+  group('ALLO', () {
+    test('ALLO with valid byte count returns 200', () async {
       final c = await FtpTestClient.connect(port);
       await c.login();
-      expect(await c.command('SITE CHMOD 755 file'), startsWith('502'));
+      final r = await c.command('ALLO 1024');
+      expect(r, startsWith('200'));
       await c.close();
     });
 
-    test('ACCT returns 202', () async {
+    test('ALLO with record size returns 200', () async {
       final c = await FtpTestClient.connect(port);
       await c.login();
-      expect(await c.command('ACCT info'), startsWith('202'));
+      final r = await c.command('ALLO 1024 R 512');
+      expect(r, startsWith('200'));
       await c.close();
     });
 
-    test('REIN resets authentication', () async {
+    test('ALLO with no argument returns 501', () async {
+      final c = await FtpTestClient.connect(port);
+      await c.login();
+      expect(await c.command('ALLO'), startsWith('501'));
+      await c.close();
+    });
+
+    test('ALLO with non-numeric argument returns 501', () async {
+      final c = await FtpTestClient.connect(port);
+      await c.login();
+      expect(await c.command('ALLO abc'), startsWith('501'));
+      await c.close();
+    });
+
+    test('ALLO with negative number returns 501', () async {
+      final c = await FtpTestClient.connect(port);
+      await c.login();
+      expect(await c.command('ALLO -1'), startsWith('501'));
+      await c.close();
+    });
+
+    test('ALLO with malformed record size returns 501', () async {
+      final c = await FtpTestClient.connect(port);
+      await c.login();
+      expect(await c.command('ALLO 1024 R'), startsWith('501'));
+      await c.close();
+    });
+
+    test('ALLO with invalid R argument returns 501', () async {
+      final c = await FtpTestClient.connect(port);
+      await c.login();
+      expect(await c.command('ALLO 1024 X 512'), startsWith('501'));
+      await c.close();
+    });
+
+    test('ALLO with non-numeric record size returns 501', () async {
+      final c = await FtpTestClient.connect(port);
+      await c.login();
+      expect(await c.command('ALLO 1024 R abc'), startsWith('501'));
+      await c.close();
+    });
+
+    test('ALLO with zero bytes returns 200', () async {
+      final c = await FtpTestClient.connect(port);
+      await c.login();
+      final r = await c.command('ALLO 0');
+      expect(r, startsWith('200'));
+      await c.close();
+    });
+  });
+
+  group('ACCT', () {
+    test('ACCT with argument returns 202', () async {
+      final c = await FtpTestClient.connect(port);
+      await c.login();
+      final r = await c.command('ACCT myaccount');
+      expect(r, startsWith('202'));
+      await c.close();
+    });
+
+    test('ACCT with no argument returns 501', () async {
+      final c = await FtpTestClient.connect(port);
+      await c.login();
+      expect(await c.command('ACCT'), startsWith('501'));
+      await c.close();
+    });
+
+    test('ACCT allowed before authentication', () async {
+      final c = await FtpTestClient.connect(port);
+      // Don't login — ACCT should still be accepted pre-auth
+      final r = await c.command('ACCT myaccount');
+      expect(r, startsWith('202'));
+      await c.close();
+    });
+  });
+
+  group('REIN', () {
+    test('REIN returns 220', () async {
+      final c = await FtpTestClient.connect(port);
+      await c.login();
+      final r = await c.command('REIN');
+      expect(r, startsWith('220'));
+      await c.close();
+    });
+
+    test('REIN resets authentication state', () async {
+      final c = await FtpTestClient.connect(port);
+      await c.login();
+      // Verify logged in
+      expect(await c.command('PWD'), startsWith('257'));
+      // Reinitialize
+      expect(await c.command('REIN'), startsWith('220'));
+      // Commands now require auth
+      expect(await c.command('PWD'), startsWith('530'));
+      await c.close();
+    });
+
+    test('REIN allows new login on same connection', () async {
       final c = await FtpTestClient.connect(port);
       await c.login();
       expect(await c.command('REIN'), startsWith('220'));
-      // After REIN, commands should require auth
-      expect(await c.command('PWD'), startsWith('530'));
+      // Login again on the same connection
+      await c.login();
+      expect(await c.command('PWD'), startsWith('257'));
+      await c.close();
+    });
+
+    test('REIN clears pending rename state', () async {
+      final c = await FtpTestClient.connect(port);
+      await c.login();
+      // Start a rename sequence
+      expect(await c.command('RNFR hello.txt'), startsWith('350'));
+      // Reinitialize — should clear the pending rename
+      expect(await c.command('REIN'), startsWith('220'));
+      // Login again
+      await c.login();
+      // RNTO should fail with 503 because RNFR was cleared by REIN
+      expect(await c.command('RNTO newname.txt'), startsWith('503'));
+      await c.close();
+    });
+
+    test('REIN allowed before authentication', () async {
+      final c = await FtpTestClient.connect(port);
+      // Don't login — REIN should still work pre-auth
+      final r = await c.command('REIN');
+      expect(r, startsWith('220'));
+      await c.close();
+    });
+
+    test('REIN resets working directory to root', () async {
+      final c = await FtpTestClient.connect(port);
+      await c.login();
+      // Change to a subdirectory
+      expect(await c.command('CWD subdir'), startsWith('250'));
+      final pwdBefore = await c.command('PWD');
+      expect(pwdBefore, contains('subdir'));
+      // Reinitialize
+      expect(await c.command('REIN'), startsWith('220'));
+      // Login again
+      await c.login();
+      // PWD should be back at root, not subdir
+      final pwdAfter = await c.command('PWD');
+      expect(pwdAfter, isNot(contains('subdir')));
+      await c.close();
+    });
+  });
+
+  group('SITE', () {
+    test('SITE with subcommand returns 502', () async {
+      final c = await FtpTestClient.connect(port);
+      await c.login();
+      final r = await c.command('SITE CHMOD 755 file.txt');
+      expect(r, startsWith('502'));
+      await c.close();
+    });
+
+    test('SITE with no argument returns 501', () async {
+      final c = await FtpTestClient.connect(port);
+      await c.login();
+      expect(await c.command('SITE'), startsWith('501'));
+      await c.close();
+    });
+
+    test('SITE with any subcommand returns 502', () async {
+      final c = await FtpTestClient.connect(port);
+      await c.login();
+      expect(await c.command('SITE HELP'), startsWith('502'));
+      expect(await c.command('SITE QUOTA'), startsWith('502'));
       await c.close();
     });
   });


### PR DESCRIPTION
## Summary
- **REIN**: Full session reinitialize with `session.reinitialize()` — resets auth, CWD, pending rename, data connections (preserves in-progress transfers per spec)
- **ALLO**: Validates byte count and optional `R <record-size>` syntax, returns 200
- **ACCT**: Validates non-empty argument, returns 202 (superfluous), allowed pre-auth
- **SITE**: Validates non-empty argument, returns 502 (not implemented)
- Updated HELP to list all supported commands
- Added REIN and ACCT to pre-auth allowed commands

## Test plan
- [x] ALLO: valid bytes, record size, zero, empty arg, non-numeric, negative, malformed R syntax
- [x] ACCT: valid arg, empty arg, pre-auth access
- [x] REIN: returns 220, resets auth, allows re-login, clears pending rename, resets CWD to root, pre-auth access
- [x] SITE: subcommand returns 502, empty arg returns 501, various subcommands
- [x] All 181 tests pass locally