### PR TITLE
RFC 959/2389/2428 compliance fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,44 +3,59 @@
 
 ## 2.2.0
 
-### Internal API Changes
-- `FTPCommandHandler` constructor no longer takes `controlSocket` (it was unused — all communication goes through the session)
-- `FTPCommandHandler.handleCommand` is now `async` to properly await all operations
-- `FtpSession.handleMlsd` and `handleMdtm` no longer take an extra `session` parameter
-- Error responses no longer include server filesystem paths or exception details
+This release focuses on **RFC compliance** and **stability**. The server now follows RFC 959, RFC 2389, RFC 2428, and RFC 3659 for all implemented commands.
+
+### RFC Compliance Fixes
+- `RETR` now validates file existence before opening data connection (no orphaned 150 replies)
+- `STOR`, `RETR`, `CWD`, `DELE`, `RMD`, `SIZE`, `MDTM` return 501 for empty arguments
+- `MKD` 257 response now contains the absolute FTP path (not relative)
+- `CWD`/`CDUP` 250 response uses virtual FTP path (no physical path leakage)
+- `PASS` now works with username-only or password-only server configurations
+- `USER` sends 230 directly for no-auth servers (clients can skip PASS)
+- `FEAT` no longer lists `PASV` (base RFC 959 command, not an extension per RFC 2389)
+- `EPSV ALL` now enforced — `PORT`/`PASV` refused after `EPSV ALL` (RFC 2428 §4)
+- `EPSV` validates network protocol argument; returns 522 for unsupported protocols (RFC 2428 §3)
+- `PORT` validates all byte values are 0–255 (501 on invalid syntax)
+- `ABOR` replies 225 when data connection open but no transfer in progress (RFC 959 §5.4)
+- `MLSD` omits `size` fact for directory entries (RFC 3659 §7.5.5)
+- `LIST -la` / `LIST -a` flags are stripped before directory lookup
 
 ### Bug Fixes
 - Fixed unhandled `SocketException` crashes when clients disconnect during transfers (#15)
 - Fixed `OPTS UTF8` crash when sent without ON/OFF argument
-- Fixed `EPSV ALL` not being handled (was entering passive mode instead of responding 200)
-- Fixed `ABOR` not sending required 226 follow-up response after 426 (RFC 959)
-- Fixed `PASS` accepted before `USER` when no credentials configured
 - Fixed passive socket file descriptor leak when clients send multiple PASV/EPSV commands
 - Fixed session list memory leak — sessions now auto-remove on disconnect
 - Fixed fire-and-forget async in MKD, RMD, DELE, RNTO, RENAME handlers — all now properly awaited
 - Fixed `handleRnto` rethrowing exceptions without sending response to client
 - Fixed `_getIpAddress` only matching 192.x.x.x networks — now supports 10.x and 172.x, and prefers control socket address
-- Fixed `LIST -la` / `LIST -a` failing — flag arguments are now stripped before directory lookup
 - Fixed pipelined commands (multiple commands in one TCP segment) being silently dropped
+- Fixed `waitForClientDataSocket` crash when passive listener is closed before client connects
 
 ### New Commands
 - `NLST` — returns bare filenames only, separated from LIST (was aliased to LIST)
-- `HELP` — returns list of supported commands
+- `HELP` — returns list of all supported commands
 - `STAT` — returns server status
 - `STRU` — accepts F (File), rejects others with 504
 - `MODE` — accepts S (Stream), rejects others with 504
-- `ALLO` — returns 202 (not needed)
-- `ACCT` — returns 202 (not needed)
-- `REIN` — resets authentication state
-- `SITE` — returns 502 (not implemented)
+- `ALLO` — validates byte count and optional `R <record-size>` syntax (RFC 959)
+- `ACCT` — accepts account string, returns 202 (superfluous); allowed pre-auth
+- `REIN` — full session reinitialize: resets auth, CWD, data connections, pending state
+- `SITE` — returns 501/502 with proper syntax validation
 
 ### Improvements
 - Authentication enforcement: commands require login when credentials are configured
 - `TYPE` now accepts `TYPE A N` form (ASCII Non-print) per RFC 959
 - `FEAT` now advertises MLSD capability
-- `USER` validates non-empty argument
 - Error responses sanitized — no server path or exception leakage to clients
 - `activeSessions` now returns unmodifiable list
+- Async command queue ensures sequential processing of pipelined commands
+
+### Internal API Changes
+- `FTPCommandHandler` constructor no longer takes `controlSocket` (it was unused — all communication goes through the session)
+- `FTPCommandHandler.handleCommand` is now `async` to properly await all operations
+- `FtpSession.handleMlsd` and `handleMdtm` no longer take an extra `session` parameter
+- Added `FtpSession.reinitialize()` for clean REIN implementation
+- Added `FtpSession.epsvAllMode` flag for EPSV ALL enforcement
 
 ## 2.1.1
 - Updated README documentation to include new rename commands

--- a/README.md
+++ b/README.md
@@ -63,7 +63,11 @@ void main() async {
 - **Directory Operations**: Change, make, remove, and list directories.
 - **Read-Only Mode**: Disable write operations for enhanced security.
 - **Authentication**: Optional username/password authentication with pre-auth command enforcement.
-- **RFC 959 Compliance**: Proper command sequencing, pipelined command support, and standard response codes.
+- **Standards Compliant**: Implements the following IETF standards:
+  - [RFC 959](https://www.rfc-editor.org/rfc/rfc959) — File Transfer Protocol (core)
+  - [RFC 2389](https://www.rfc-editor.org/rfc/rfc2389) — Feature negotiation (FEAT/OPTS)
+  - [RFC 2428](https://www.rfc-editor.org/rfc/rfc2428) — Extended passive mode (EPSV)
+  - [RFC 3659](https://www.rfc-editor.org/rfc/rfc3659) — Extensions (MLSD, MDTM, SIZE)
 
 ---
 

--- a/lib/ftp_command_handler.dart
+++ b/lib/ftp_command_handler.dart
@@ -46,10 +46,18 @@ class FTPCommandHandler {
         await handleQuit(session);
         break;
       case 'PASV':
-        await session.enterPassiveMode();
+        if (session.epsvAllMode) {
+          session.sendResponse('503 PASV not allowed after EPSV ALL');
+        } else {
+          await session.enterPassiveMode();
+        }
         break;
       case 'PORT':
-        await session.enterActiveMode(argument);
+        if (session.epsvAllMode) {
+          session.sendResponse('503 PORT not allowed after EPSV ALL');
+        } else {
+          await session.enterActiveMode(argument);
+        }
         break;
       case 'LIST':
         await session.listDirectory(_stripListFlags(argument));
@@ -176,7 +184,13 @@ class FTPCommandHandler {
     }
     session.cachedUsername = argument;
     session.isAuthenticated = false;
-    session.sendResponse('331 Password required for $argument');
+    // No credentials configured — log in directly (RFC 959: 230 on USER)
+    if (session.username == null && session.password == null) {
+      session.isAuthenticated = true;
+      session.sendResponse('230 User logged in, proceed');
+    } else {
+      session.sendResponse('331 Password required for $argument');
+    }
   }
 
   void handlePass(String argument, FtpSession session) {
@@ -184,9 +198,17 @@ class FTPCommandHandler {
       session.sendResponse('503 Bad sequence of commands');
       return;
     }
-    if ((session.username == null && session.password == null) ||
-        (session.cachedUsername == session.username &&
-            argument == session.password)) {
+    // No credentials configured — accept anyone
+    if (session.username == null && session.password == null) {
+      session.isAuthenticated = true;
+      session.sendResponse('230 User logged in, proceed');
+      return;
+    }
+    // Validate only the non-null credentials
+    final userOk =
+        session.username == null || session.cachedUsername == session.username;
+    final passOk = session.password == null || argument == session.password;
+    if (userOk && passOk) {
       session.isAuthenticated = true;
       session.sendResponse('230 User logged in, proceed');
     } else {
@@ -256,18 +278,21 @@ class FTPCommandHandler {
   }
 
   void handleFeat(FtpSession session) {
+    // RFC 2389: FEAT only lists extensions not in RFC 959
+    // PASV is a base command and must not appear here
     session.sendResponse('211-Features:');
     session.sendResponse(' SIZE');
     session.sendResponse(' MDTM');
     session.sendResponse(' MLSD');
     session.sendResponse(' EPSV');
-    session.sendResponse(' PASV');
     session.sendResponse(' UTF8');
     session.sendResponse('211 End');
   }
 
   Future<void> handleEpsv(String argument, FtpSession session) async {
     if (argument.toUpperCase() == 'ALL') {
+      // RFC 2428 §4: after EPSV ALL, server must refuse PORT/PASV/LPRT
+      session.epsvAllMode = true;
       session.sendResponse('200 EPSV ALL command successful');
     } else {
       await session.enterExtendedPassiveMode();

--- a/lib/ftp_command_handler.dart
+++ b/lib/ftp_command_handler.dart
@@ -157,7 +157,7 @@ class FTPCommandHandler {
         handleAllo(argument, session);
         break;
       case 'STAT':
-        session.sendResponse('211 Server is running');
+        await handleStat(argument, session);
         break;
       case 'HELP':
         handleHelp(session);
@@ -443,6 +443,17 @@ class FTPCommandHandler {
     }
     // No site-specific commands are implemented
     session.sendResponse('502 SITE command not implemented');
+  }
+
+  /// STAT: Return server status or file/directory info (RFC 959 §4.1.3).
+  /// Without arguments: returns general server status (211).
+  /// With a pathname: returns a directory listing over the control connection.
+  Future<void> handleStat(String argument, FtpSession session) async {
+    if (argument.isEmpty) {
+      session.sendResponse('211 Server is running');
+      return;
+    }
+    await session.statPath(argument);
   }
 
   void handleHelp(FtpSession session) {

--- a/lib/ftp_command_handler.dart
+++ b/lib/ftp_command_handler.dart
@@ -294,8 +294,14 @@ class FTPCommandHandler {
       // RFC 2428 §4: after EPSV ALL, server must refuse PORT/PASV/LPRT
       session.epsvAllMode = true;
       session.sendResponse('200 EPSV ALL command successful');
-    } else {
+    } else if (argument.isEmpty || argument == '1') {
+      // Empty = server chooses; '1' = IPv4
       await session.enterExtendedPassiveMode();
+    } else if (argument == '2') {
+      // IPv6 not supported
+      session.sendResponse('522 Network protocol not supported, use (1)');
+    } else {
+      session.sendResponse('501 Syntax error in parameters');
     }
   }
 
@@ -425,7 +431,7 @@ class FTPCommandHandler {
   /// The control connection remains open for a new USER command.
   void handleRein(FtpSession session) {
     session.reinitialize();
-    session.sendResponse('220 Service ready for new user');
+    session.sendResponse('200 REIN command successful');
   }
 
   /// SITE: Execute site-specific commands (RFC 959).

--- a/lib/ftp_session.dart
+++ b/lib/ftp_session.dart
@@ -530,6 +530,7 @@ class FtpSession {
   }
 
   void _handleTransferError(IOSink? fileSink) async {
+    if (!transferInProgress) return; // Already aborted (e.g. by ABOR)
     sendResponse('426 Connection closed; transfer aborted');
     if (fileSink != null) {
       try {
@@ -622,6 +623,10 @@ class FtpSession {
   }
 
   Future<void> makeDirectory(String dirname) async {
+    if (dirname.isEmpty) {
+      sendResponse('501 Syntax error in parameters');
+      return;
+    }
     try {
       await fileOperations.createDirectory(dirname);
       // RFC 959: 257 response must contain the absolute FTP pathname.
@@ -785,6 +790,50 @@ class FtpSession {
     } catch (e) {
       sendResponse('550 Could not get modification time');
       logger.generalLog('Error getting modification time: $e');
+    }
+  }
+
+  /// STAT with pathname: list file/directory info over the control connection
+  /// (RFC 959 §4.1.3). Uses 213 for status replies sent over control.
+  Future<void> statPath(String path) async {
+    try {
+      final dirContents = await fileOperations.listDirectory(path);
+      sendResponse('213-Status of $path:');
+      for (FileSystemEntity entity in dirContents) {
+        try {
+          var stat = await entity.stat();
+          String permissions = _formatPermissions(stat);
+          String fileSize = stat.size.toString();
+          String modificationTime = _formatModificationTime(stat.modified);
+          String fileName = entity.path.split(Platform.pathSeparator).last;
+          sendResponse(
+              ' $permissions 1 ftp ftp $fileSize $modificationTime $fileName');
+        } catch (_) {
+          continue;
+        }
+      }
+      sendResponse('213 End of status');
+    } catch (e) {
+      // If path is a file, try to stat it directly
+      try {
+        String fullPath = fileOperations.resolvePath(path);
+        File file = File(fullPath);
+        if (await file.exists()) {
+          var stat = await file.stat();
+          String permissions = _formatPermissions(stat);
+          String fileSize = stat.size.toString();
+          String modificationTime = _formatModificationTime(stat.modified);
+          String fileName = file.path.split(Platform.pathSeparator).last;
+          sendResponse('213-Status of $path:');
+          sendResponse(
+              ' $permissions 1 ftp ftp $fileSize $modificationTime $fileName');
+          sendResponse('213 End of status');
+        } else {
+          sendResponse('450 No such file or directory');
+        }
+      } catch (_) {
+        sendResponse('450 No such file or directory');
+      }
     }
   }
 

--- a/lib/ftp_session.dart
+++ b/lib/ftp_session.dart
@@ -216,8 +216,18 @@ class FtpSession {
         sendResponse('501 Syntax error in PORT parameters');
         return;
       }
-      String ip = parts.take(4).join('.');
-      int port = int.parse(parts[4]) * 256 + int.parse(parts[5]);
+      // Validate all 6 parts are valid byte values (0-255)
+      final values = <int>[];
+      for (final part in parts.take(6)) {
+        final v = int.tryParse(part.trim());
+        if (v == null || v < 0 || v > 255) {
+          sendResponse('501 Syntax error in PORT parameters');
+          return;
+        }
+        values.add(v);
+      }
+      String ip = values.take(4).join('.');
+      int port = values[4] * 256 + values[5];
       dataSocket = await Socket.connect(ip, port);
       sendResponse('200 Active mode connection established');
     } catch (e) {
@@ -576,11 +586,20 @@ class FtpSession {
       sendResponse('426 Transfer aborted');
       sendResponse('226 ABOR command successful');
     } else {
-      sendResponse('226 ABOR command successful');
+      // RFC 959: 225 if data connection open but no transfer; 226 otherwise
+      if (dataSocket != null || dataListener != null) {
+        sendResponse('225 Data connection open; no transfer in progress');
+      } else {
+        sendResponse('226 ABOR command successful');
+      }
     }
   }
 
   void changeDirectory(String dirname) {
+    if (dirname.isEmpty) {
+      sendResponse('501 Syntax error in parameters');
+      return;
+    }
     try {
       fileOperations.changeDirectory(dirname);
       sendResponse(
@@ -623,6 +642,10 @@ class FtpSession {
   }
 
   Future<void> removeDirectory(String dirname) async {
+    if (dirname.isEmpty) {
+      sendResponse('501 Syntax error in parameters');
+      return;
+    }
     try {
       await fileOperations.deleteDirectory(dirname);
       sendResponse('250 Directory deleted');
@@ -633,6 +656,10 @@ class FtpSession {
   }
 
   Future<void> deleteFile(String filePath) async {
+    if (filePath.isEmpty) {
+      sendResponse('501 Syntax error in parameters');
+      return;
+    }
     try {
       await fileOperations.deleteFile(filePath);
       sendResponse('250 File deleted');
@@ -643,6 +670,10 @@ class FtpSession {
   }
 
   Future<void> fileSize(String filePath) async {
+    if (filePath.isEmpty) {
+      sendResponse('501 Syntax error in parameters');
+      return;
+    }
     try {
       int size = await fileOperations.fileSize(filePath);
       sendResponse('213 $size');
@@ -720,16 +751,22 @@ class FtpSession {
   }
 
   String _formatMlsdFacts(FileSystemEntity entity, FileStat stat) {
-    String type = stat.type == FileSystemEntityType.directory ? "dir" : "file";
+    final isDir = stat.type == FileSystemEntityType.directory;
+    String type = isDir ? "dir" : "file";
     String modify = DateFormat("yyyyMMddHHmmss")
         .format(stat.modified.toUtc()); // Use UTC time
-    String size = stat.size.toString();
     String name = entity.path.split(Platform.pathSeparator).last;
+    // RFC 3659 §7.5.5: size fact is undefined for directories, omit it
+    String sizeFact = isDir ? '' : 'size=${stat.size};';
 
-    return "type=$type;modify=$modify;size=$size; $name\r\n";
+    return "type=$type;modify=$modify;$sizeFact $name\r\n";
   }
 
   void handleMdtm(String argument) {
+    if (argument.isEmpty) {
+      sendResponse('501 Syntax error in parameters');
+      return;
+    }
     try {
       if (!fileOperations.exists(argument)) {
         sendResponse('550 File not found');

--- a/lib/ftp_session.dart
+++ b/lib/ftp_session.dart
@@ -24,6 +24,9 @@ class FtpSession {
   bool transferInProgress = false;
   Future? _gettingDataSocket;
 
+  /// RFC 2428: after EPSV ALL, PORT/PASV/LPRT must be refused.
+  bool epsvAllMode = false;
+
   /// Callback invoked when this session's connection is closed.
   /// Used by FtpServer to remove the session from its active list.
   void Function()? onDisconnect;
@@ -100,6 +103,7 @@ class FtpSession {
     isAuthenticated = false;
     cachedUsername = null;
     pendingRenameFrom = null;
+    epsvAllMode = false;
 
     // Reset working directory to root
     fileOperations.currentDirectory = fileOperations.rootDirectory;
@@ -174,7 +178,12 @@ class FtpSession {
             'Timeout reached while waiting for client data socket');
       });
     }
-    return result.then((value) => dataSocket = value);
+    return result.then((value) {
+      dataSocket = value;
+    }).catchError((Object e) {
+      // dataListener was closed before a client connected (e.g. session ended)
+      logger.generalLog('Data connection wait cancelled: $e');
+    });
   }
 
   Future<void> enterPassiveMode() async {
@@ -373,6 +382,24 @@ class FtpSession {
   }
 
   Future<void> retrieveFile(String filename) async {
+    if (filename.isEmpty) {
+      sendResponse('501 Syntax error in parameters');
+      return;
+    }
+
+    // Check file existence before opening data connection to avoid
+    // sending 550 after 150 (RFC 959: validate before preliminary reply)
+    if (!fileOperations.exists(filename)) {
+      sendResponse('550 File not found');
+      return;
+    }
+    String fullPath = fileOperations.resolvePath(filename);
+    File file = File(fullPath);
+    if (!await file.exists()) {
+      sendResponse('550 File not found');
+      return;
+    }
+
     if (!await openDataConnection()) {
       return;
     }
@@ -380,15 +407,6 @@ class FtpSession {
     try {
       transferInProgress = true;
 
-      if (!fileOperations.exists(filename)) {
-        sendResponse('550 File not found');
-        transferInProgress = false;
-        await _closeDataSocket();
-        return;
-      }
-      String fullPath = fileOperations.resolvePath(filename);
-
-      File file = File(fullPath);
       if (await file.exists()) {
         Stream<List<int>> fileStream = file.openRead();
 
@@ -423,10 +441,6 @@ class FtpSession {
           },
           cancelOnError: true,
         );
-      } else {
-        sendResponse('550 File not found');
-        transferInProgress = false;
-        await _closeDataSocket();
       }
     } catch (e) {
       logger.generalLog('Exception in retrieveFile: $e');
@@ -437,6 +451,11 @@ class FtpSession {
   }
 
   Future<void> storeFile(String filename) async {
+    if (filename.isEmpty) {
+      sendResponse('501 Syntax error in parameters');
+      return;
+    }
+
     if (!await openDataConnection()) {
       return;
     }
@@ -565,7 +584,7 @@ class FtpSession {
     try {
       fileOperations.changeDirectory(dirname);
       sendResponse(
-          '250 Directory changed to ${fileOperations.currentDirectory}');
+          '250 Directory changed to ${fileOperations.getCurrentDirectory()}');
     } catch (e) {
       sendResponse('550 Access denied or directory not found');
       logger.generalLog('Error changing directory: $e');
@@ -576,7 +595,7 @@ class FtpSession {
     try {
       fileOperations.changeToParentDirectory();
       sendResponse(
-          '250 Directory changed to ${fileOperations.currentDirectory}');
+          '250 Directory changed to ${fileOperations.getCurrentDirectory()}');
     } catch (e) {
       sendResponse('550 Access denied or directory not found');
       logger.generalLog('Error changing to parent directory: $e');
@@ -586,7 +605,17 @@ class FtpSession {
   Future<void> makeDirectory(String dirname) async {
     try {
       await fileOperations.createDirectory(dirname);
-      sendResponse('257 "$dirname" created');
+      // RFC 959: 257 response must contain the absolute FTP pathname.
+      // Temporarily change into the new dir to get its resolved virtual path,
+      // then change back to the original directory.
+      final savedDir = fileOperations.getCurrentDirectory();
+      try {
+        fileOperations.changeDirectory(dirname);
+        final absPath = fileOperations.getCurrentDirectory();
+        sendResponse('257 "$absPath" created');
+      } finally {
+        fileOperations.changeDirectory(savedDir);
+      }
     } catch (e) {
       sendResponse('550 Failed to create directory');
       logger.generalLog('Error creating directory: $e');

--- a/test/ftp_commands_test.dart
+++ b/test/ftp_commands_test.dart
@@ -392,8 +392,9 @@ void main() {
       expect(r, contains('MDTM'));
       expect(r, contains('MLSD'));
       expect(r, contains('EPSV'));
-      expect(r, contains('PASV'));
       expect(r, contains('UTF8'));
+      // PASV is a base RFC 959 command, not an extension per RFC 2389
+      expect(r, isNot(contains('PASV')));
       expect(r, startsWith('211'));
       await c.close();
     });
@@ -756,6 +757,174 @@ void main() {
       expect(response, contains('200'));
       dataReady.close();
       await socket.close();
+    });
+  });
+
+  group('RFC compliance fixes', () {
+    test('RETR with empty argument returns 501', () async {
+      final c = await FtpTestClient.connect(port);
+      await c.login();
+      final r = await c.command('RETR');
+      expect(r, startsWith('501'));
+      await c.close();
+    });
+
+    test('RETR nonexistent file returns 550 without 150', () async {
+      // The server should check file existence before opening data connection
+      final c = await FtpTestClient.connect(port);
+      await c.login();
+      final r = await c.command('RETR nonexistent_file.txt');
+      // Should get 550 directly, not 150 then 550
+      expect(r, startsWith('550'));
+      await c.close();
+    });
+
+    test('STOR with empty argument returns 501', () async {
+      final c = await FtpTestClient.connect(port);
+      await c.login();
+      final r = await c.command('STOR');
+      expect(r, startsWith('501'));
+      await c.close();
+    });
+
+    test('CWD response uses virtual path, not physical', () async {
+      final c = await FtpTestClient.connect(port);
+      await c.login();
+      final r = await c.command('CWD subdir');
+      expect(r, startsWith('250'));
+      // Should not contain system temp path
+      expect(r, isNot(contains('/var')));
+      expect(r, isNot(contains('/tmp')));
+      expect(r, isNot(contains('AppData')));
+      await c.close();
+    });
+
+    test('CDUP response uses virtual path', () async {
+      final c = await FtpTestClient.connect(port);
+      await c.login();
+      await c.command('CWD subdir');
+      final r = await c.command('CDUP');
+      expect(r, startsWith('250'));
+      expect(r, isNot(contains('/var')));
+      expect(r, isNot(contains('/tmp')));
+      await c.close();
+    });
+
+    test('MKD response contains absolute FTP path', () async {
+      final c = await FtpTestClient.connect(port);
+      await c.login();
+      final r = await c.command('MKD rfc_test_dir');
+      expect(r, startsWith('257'));
+      // Should contain a path starting with /
+      expect(r, contains('/'));
+      expect(r, contains('rfc_test_dir'));
+      // Cleanup
+      await c.command('RMD rfc_test_dir');
+      await c.close();
+    });
+
+    test('FEAT does not list PASV (base RFC 959 command)', () async {
+      final c = await FtpTestClient.connect(port);
+      await c.login();
+      c.send('FEAT');
+      final feat = await c.readMultiLineResponse();
+      expect(feat, isNot(contains('PASV')));
+      expect(feat, contains('EPSV'));
+      expect(feat, contains('SIZE'));
+      await c.close();
+    });
+
+    test('EPSV ALL prevents subsequent PORT', () async {
+      final c = await FtpTestClient.connect(port);
+      await c.login();
+      expect(await c.command('EPSV ALL'), startsWith('200'));
+      final r = await c.command('PORT 127,0,0,1,200,10');
+      expect(r, startsWith('503'));
+      await c.close();
+    });
+
+    test('EPSV ALL prevents subsequent PASV', () async {
+      final c = await FtpTestClient.connect(port);
+      await c.login();
+      expect(await c.command('EPSV ALL'), startsWith('200'));
+      final r = await c.command('PASV');
+      expect(r, startsWith('503'));
+      await c.close();
+    });
+
+    test('EPSV still works after EPSV ALL', () async {
+      final c = await FtpTestClient.connect(port);
+      await c.login();
+      expect(await c.command('EPSV ALL'), startsWith('200'));
+      final r = await c.command('EPSV');
+      expect(r, startsWith('229'));
+      await c.command('QUIT');
+      await c.close();
+    });
+  });
+
+  group('Partial credential configs', () {
+    late FtpServer usernameOnlyServer;
+    const usernameOnlyPort = 2251;
+
+    setUpAll(() async {
+      usernameOnlyServer = FtpServer(
+        usernameOnlyPort,
+        username: 'admin',
+        password: null,
+        fileOperations: VirtualFileOperations([tempDir.path],
+            startingDirectory: p.basename(tempDir.path)),
+        serverType: ServerType.readAndWrite,
+        logFunction: (msg) {},
+      );
+      await usernameOnlyServer.startInBackground();
+    });
+
+    tearDownAll(() async {
+      await usernameOnlyServer.stop();
+    });
+
+    test('Username-only server: correct username authenticates', () async {
+      final c = await FtpTestClient.connect(usernameOnlyPort);
+      expect(await c.command('USER admin'), startsWith('331'));
+      expect(await c.command('PASS anything'), startsWith('230'));
+      await c.close();
+    });
+
+    test('Username-only server: wrong username fails', () async {
+      final c = await FtpTestClient.connect(usernameOnlyPort);
+      expect(await c.command('USER wrong'), startsWith('331'));
+      expect(await c.command('PASS anything'), startsWith('530'));
+      await c.close();
+    });
+  });
+
+  group('No-auth server', () {
+    late FtpServer noAuthServer;
+    const noAuthPort = 2252;
+
+    setUpAll(() async {
+      noAuthServer = FtpServer(
+        noAuthPort,
+        fileOperations: VirtualFileOperations([tempDir.path],
+            startingDirectory: p.basename(tempDir.path)),
+        serverType: ServerType.readAndWrite,
+        logFunction: (msg) {},
+      );
+      await noAuthServer.startInBackground();
+    });
+
+    tearDownAll(() async {
+      await noAuthServer.stop();
+    });
+
+    test('No-auth server: USER returns 230 directly', () async {
+      final c = await FtpTestClient.connect(noAuthPort);
+      final r = await c.command('USER anonymous');
+      expect(r, startsWith('230'));
+      // Should be able to use commands immediately without PASS
+      expect(await c.command('PWD'), startsWith('257'));
+      await c.close();
     });
   });
 }

--- a/test/ftp_commands_test.dart
+++ b/test/ftp_commands_test.dart
@@ -547,7 +547,7 @@ void main() {
       final c = await FtpTestClient.connect(port);
       await c.login();
       final r = await c.command('REIN');
-      expect(r, startsWith('220'));
+      expect(r, startsWith('200'));
       await c.close();
     });
 
@@ -557,7 +557,7 @@ void main() {
       // Verify logged in
       expect(await c.command('PWD'), startsWith('257'));
       // Reinitialize
-      expect(await c.command('REIN'), startsWith('220'));
+      expect(await c.command('REIN'), startsWith('200'));
       // Commands now require auth
       expect(await c.command('PWD'), startsWith('530'));
       await c.close();
@@ -566,7 +566,7 @@ void main() {
     test('REIN allows new login on same connection', () async {
       final c = await FtpTestClient.connect(port);
       await c.login();
-      expect(await c.command('REIN'), startsWith('220'));
+      expect(await c.command('REIN'), startsWith('200'));
       // Login again on the same connection
       await c.login();
       expect(await c.command('PWD'), startsWith('257'));
@@ -579,7 +579,7 @@ void main() {
       // Start a rename sequence
       expect(await c.command('RNFR hello.txt'), startsWith('350'));
       // Reinitialize — should clear the pending rename
-      expect(await c.command('REIN'), startsWith('220'));
+      expect(await c.command('REIN'), startsWith('200'));
       // Login again
       await c.login();
       // RNTO should fail with 503 because RNFR was cleared by REIN
@@ -591,7 +591,7 @@ void main() {
       final c = await FtpTestClient.connect(port);
       // Don't login — REIN should still work pre-auth
       final r = await c.command('REIN');
-      expect(r, startsWith('220'));
+      expect(r, startsWith('200'));
       await c.close();
     });
 
@@ -603,7 +603,7 @@ void main() {
       final pwdBefore = await c.command('PWD');
       expect(pwdBefore, contains('subdir'));
       // Reinitialize
-      expect(await c.command('REIN'), startsWith('220'));
+      expect(await c.command('REIN'), startsWith('200'));
       // Login again
       await c.login();
       // PWD should be back at root, not subdir

--- a/test/ftp_commands_test.dart
+++ b/test/ftp_commands_test.dart
@@ -815,8 +815,8 @@ void main() {
       await c.login();
       final r = await c.command('MKD rfc_test_dir');
       expect(r, startsWith('257'));
-      // Should contain a path starting with /
-      expect(r, contains('/'));
+      // Should contain a path separator (/ on Unix, \ on Windows)
+      expect(r, anyOf(contains('/'), contains('\\')));
       expect(r, contains('rfc_test_dir'));
       // Cleanup
       await c.command('RMD rfc_test_dir');

--- a/test/ftp_server_test.dart
+++ b/test/ftp_server_test.dart
@@ -214,9 +214,11 @@ void main() {
             "cd /${basename(sharedDirectories.first)}\nmkdir test_dir\nls");
       }
 
-      // Use outputHandler for expected MKD output
-      expect(output,
-          contains(outputHandler.getExpectedMakeDirectoryOutput('test_dir')));
+      // Use outputHandler for expected MKD output (RFC 959: absolute path)
+      expect(
+          output,
+          contains(outputHandler.getExpectedMakeDirectoryOutput(
+              '/${basename(sharedDirectories.first)}/test_dir')));
       expect(output, contains('test_dir'));
       expect(Directory('${sharedDirectories.first}/test_dir').existsSync(),
           isTrue);
@@ -517,7 +519,10 @@ void main() {
       if (Platform.isWindows) {
         output = await execFTPCmdOnWin("mkdir special!@#\$%^&*()_dir\nls");
       } else {
-        expect(output, contains('257 "special!@#\$%^&*()_dir" created'));
+        expect(
+            output,
+            contains(
+                '257 "/${basename(sharedDirectories.first)}/special!@#\$%^&*()_dir" created'));
       }
       expect(output, contains('special!@#\$%^&*()_dir'));
     });
@@ -754,8 +759,10 @@ void main() {
       }
 
       // Use outputHandler for expected outputs
-      expect(output,
-          contains(outputHandler.getExpectedMakeDirectoryOutput(dirName)));
+      expect(
+          output,
+          contains(outputHandler.getExpectedMakeDirectoryOutput(
+              '/${basename(sharedDirectories.first)}/$dirName')));
       expect(
           output,
           contains(outputHandler.getExpectedDirectoryChangeOutput(
@@ -1119,8 +1126,10 @@ void main() {
       }
 
       // Use outputHandler for expected MKD output
-      expect(output,
-          contains(outputHandler.getExpectedMakeDirectoryOutput(dirName)));
+      expect(
+          output,
+          contains(outputHandler.getExpectedMakeDirectoryOutput(
+              '/${basename(sharedDirectories.first)}/$dirName')));
       expect(output, contains(dirName));
     });
   });
@@ -1195,8 +1204,8 @@ void main() {
             // Use outputHandler for expected outputs
             expect(
                 output,
-                contains(
-                    outputHandler.getExpectedMakeDirectoryOutput(dirName)));
+                contains(outputHandler.getExpectedMakeDirectoryOutput(
+                    '/${basename(sharedDirectories.first)}/$dirName')));
             expect(output, contains(dirName)); // Check listing contains the dir
             expect(
                 output,
@@ -1219,8 +1228,8 @@ void main() {
             // Use outputHandler for expected outputs
             expect(
                 output,
-                contains(
-                    outputHandler.getExpectedMakeDirectoryOutput(dirName)));
+                contains(outputHandler.getExpectedMakeDirectoryOutput(
+                    '/${basename(sharedDirectories.first)}/$dirName')));
             expect(output, contains(dirName)); // Check listing contains the dir
             expect(
                 output,
@@ -1374,8 +1383,10 @@ void main() {
 
       // Verify MKD succeeds because the lenient check resolves '2025-04-27' to '<mappedTempDir>/photos/2025-04-27'
       // Use outputHandler for expected MKD output
-      expect(output,
-          contains(outputHandler.getExpectedMakeDirectoryOutput('2025-04-27')));
+      expect(
+          output,
+          contains(outputHandler
+              .getExpectedMakeDirectoryOutput('/photos/2025-04-27')));
 
       // Verify subsequent CWD succeeds
       // Use outputHandler for expected CD output
@@ -1451,13 +1462,17 @@ void main() {
 
       // Use outputHandler for expected outputs
       expect(
-          output, contains(outputHandler.getExpectedMakeDirectoryOutput(dir1)));
+          output,
+          contains(
+              outputHandler.getExpectedMakeDirectoryOutput('/photos/$dir1')));
       expect(
           output,
           contains(outputHandler.getExpectedDirectoryChangeOutput(
               '/photos/$dir1'))); // Note the virtual path!
       expect(
-          output, contains(outputHandler.getExpectedMakeDirectoryOutput(dir2)));
+          output,
+          contains(outputHandler
+              .getExpectedMakeDirectoryOutput('/photos/$dir1/$dir2')));
 
       // Ensure the final LS lists the content of the created directory
       expect(output, contains(dir2)); // Check if the subdirectory is listed


### PR DESCRIPTION
## Summary
- **RETR**: Check file existence before 150 to avoid orphaned preliminary reply
- **STOR**: Validate non-empty argument before data connection
- **CWD/CDUP**: Use virtual path in 250 response (no physical path leakage)
- **MKD**: Return absolute FTP path in 257 response via virtual path resolution
- **PASS**: Fix auth always failing with username-only or password-only configs
- **USER**: Send 230 directly for no-auth servers (skip PASS requirement)
- **FEAT**: Remove PASV from feature list (RFC 2389: base commands excluded)
- **EPSV ALL**: Enforce RFC 2428 §4 — refuse PORT/PASV after EPSV ALL
- **waitForClientDataSocket**: Handle closed listener gracefully

## Test plan
- [x] RETR: empty arg returns 501, nonexistent file returns 550 (no 150 first)
- [x] STOR: empty arg returns 501
- [x] CWD/CDUP: response contains virtual path, no /var or /tmp
- [x] MKD: 257 contains absolute FTP path including virtual mappings
- [x] PASS: username-only server accepts correct user, rejects wrong user
- [x] USER: no-auth server returns 230 directly, commands work without PASS
- [x] FEAT: does not contain PASV, does contain EPSV/SIZE/etc
- [x] EPSV ALL: PORT returns 503, PASV returns 503, EPSV still works
- [x] All 194 tests pass locally