### PR TITLE
fix: prefer WiFi IP in PASV response on Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 
 # Changelog
 
+## 2.3.2
+
+- Fixed `PASV`/`EPSV` advertising the wrong local IP on Android and other multi-interface hosts, where the carrier-internal `10.x` address could be returned instead of the WiFi address. Interface scan now prefers `wlan0` → `en0` → `192.168.*` → `172.*` → `10.*`. Thanks to [@usman-flutter-dev](https://github.com/usman-flutter-dev) (#29).
+
 ## 2.3.1
 
 - Updated README with comprehensive documentation for all features

--- a/lib/ftp_session.dart
+++ b/lib/ftp_session.dart
@@ -7,6 +7,7 @@ import 'package:intl/intl.dart';
 import 'ftp_command_handler.dart';
 import 'logger_handler.dart';
 import 'file_operations/file_operations.dart';
+import 'src/pasv_ip_selector.dart';
 
 class FtpSession {
   Socket _controlSocket;
@@ -368,24 +369,24 @@ class FtpSession {
   }
 
   Future<String> _getIpAddress() async {
-    // Step 1: Try control socket first
+    // Step 1: capture the control socket's local address, if it is IPv4 and
+    // not loopback. The actual "is this address usable?" decision (rejecting
+    // 0.0.0.0 / 10.x) lives inside [selectPasvIp] so it can be unit tested.
+    String? controlSocketAddress;
     try {
       final addr = _controlSocket.address;
-      if (addr.type == InternetAddressType.IPv4 &&
-          !addr.isLoopback &&
-          addr.address != '0.0.0.0' &&
-          !addr.address.startsWith('10.')) {
-        return addr.address;
+      if (addr.type == InternetAddressType.IPv4 && !addr.isLoopback) {
+        controlSocketAddress = addr.address;
       }
     } catch (_) {}
 
-    // Step 2: Scan network interfaces
+    // Step 2: enumerate non-loopback, non-link-local IPv4 candidates from
+    // every interface on the host.
+    final candidates = <PasvIpCandidate>[];
     try {
       final interfaces = await NetworkInterface.list(
         type: InternetAddressType.IPv4,
       );
-
-      final candidates = <({String ip, String ifaceName})>[];
       for (final iface in interfaces) {
         for (final addr in iface.addresses) {
           if (!addr.isLoopback && !addr.isLinkLocal) {
@@ -393,23 +394,14 @@ class FtpSession {
           }
         }
       }
-
-      if (candidates.isEmpty) return '0.0.0.0';
-
-      return candidates.where((c) => c.ifaceName == 'wlan0').firstOrNull?.ip ??
-          candidates.where((c) => c.ifaceName == 'en0').firstOrNull?.ip ??
-          candidates
-              .where((c) => c.ip.startsWith('192.168.'))
-              .firstOrNull
-              ?.ip ??
-          candidates.where((c) => c.ip.startsWith('172.')).firstOrNull?.ip ??
-          candidates.where((c) => c.ip.startsWith('10.')).firstOrNull?.ip ??
-          candidates.first.ip;
     } catch (e) {
       logger.generalLog('Error getting IP address: $e');
     }
 
-    return '0.0.0.0';
+    return selectPasvIp(
+      controlSocketAddress: controlSocketAddress,
+      candidates: candidates,
+    );
   }
 
   Future<void> listDirectory(String path) async {

--- a/lib/ftp_session.dart
+++ b/lib/ftp_session.dart
@@ -368,42 +368,47 @@ class FtpSession {
   }
 
   Future<String> _getIpAddress() async {
-    // Use the control socket's local address if available
+    // Step 1: Try control socket first
     try {
       final addr = _controlSocket.address;
       if (addr.type == InternetAddressType.IPv4 &&
           !addr.isLoopback &&
-          addr.address != '0.0.0.0') {
+          addr.address != '0.0.0.0' &&
+          !addr.address.startsWith('10.')) {
         return addr.address;
       }
     } catch (_) {}
 
-    // Fallback: scan network interfaces for a private IPv4 address
+    // Step 2: Scan network interfaces
     try {
-      final networkInterfaces = await NetworkInterface.list();
-      final ipList = networkInterfaces
-          .map((interface) => interface.addresses)
-          .expand((ip) => ip)
-          .where((ip) =>
-              ip.type == InternetAddressType.IPv4 &&
-              !ip.isLoopback &&
-              !ip.isLinkLocal)
-          .toList();
+      final interfaces = await NetworkInterface.list(
+        type: InternetAddressType.IPv4,
+      );
 
-      if (ipList.isNotEmpty) {
-        // Prefer private network addresses
-        final privateIp = ipList.firstWhere(
-          (address) =>
-              address.address.startsWith('192.') ||
-              address.address.startsWith('10.') ||
-              address.address.startsWith('172.'),
-          orElse: () => ipList.first,
-        );
-        return privateIp.address;
+      final candidates = <({String ip, String ifaceName})>[];
+      for (final iface in interfaces) {
+        for (final addr in iface.addresses) {
+          if (!addr.isLoopback && !addr.isLinkLocal) {
+            candidates.add((ip: addr.address, ifaceName: iface.name));
+          }
+        }
       }
+
+      if (candidates.isEmpty) return '0.0.0.0';
+
+      return candidates.where((c) => c.ifaceName == 'wlan0').firstOrNull?.ip ??
+          candidates.where((c) => c.ifaceName == 'en0').firstOrNull?.ip ??
+          candidates
+              .where((c) => c.ip.startsWith('192.168.'))
+              .firstOrNull
+              ?.ip ??
+          candidates.where((c) => c.ip.startsWith('172.')).firstOrNull?.ip ??
+          candidates.where((c) => c.ip.startsWith('10.')).firstOrNull?.ip ??
+          candidates.first.ip;
     } catch (e) {
       logger.generalLog('Error getting IP address: $e');
     }
+
     return '0.0.0.0';
   }
 

--- a/lib/src/pasv_ip_selector.dart
+++ b/lib/src/pasv_ip_selector.dart
@@ -1,0 +1,59 @@
+/// IP selection helper for the PASV/EPSV response advertised by
+/// [FtpSession]. Split out of `ftp_session.dart` so it can be unit tested
+/// without needing real sockets or a live `NetworkInterface.list()`.
+///
+/// This file lives under `lib/src/` because it is an implementation detail —
+/// not part of the public API. Tests import it directly via
+/// `package:ftp_server/src/pasv_ip_selector.dart`.
+library;
+
+/// A non-loopback, non-link-local IPv4 candidate discovered on a network
+/// interface, tagged with the interface name it came from.
+typedef PasvIpCandidate = ({String ip, String ifaceName});
+
+/// Picks the local IPv4 address that should be advertised in a PASV/EPSV
+/// response.
+///
+/// The selection rules mirror what mainstream FTP clients expect to see on
+/// multi-interface hosts (notably Android phones, which simultaneously expose
+/// `wlan0` → `192.168.x.x` and `rmnet*` → `10.x.x.x`):
+///
+///   1. [controlSocketAddress] — if it looks like a usable, routable address
+///      (IPv4, not `0.0.0.0`, not loopback, not in the carrier-internal
+///      `10.0.0.0/8` range). This is the most accurate source because it is
+///      literally the address the client is already talking to.
+///   2. An interface literally named `wlan0` (Android WiFi).
+///   3. An interface literally named `en0` (iOS/macOS WiFi).
+///   4. Any `192.168.*` candidate (home/office router).
+///   5. Any `172.*` candidate (enterprise network).
+///   6. Any `10.*` candidate (last resort — may be carrier-internal).
+///   7. The first candidate in the list.
+///   8. `"0.0.0.0"` if there is nothing else to return.
+///
+/// [controlSocketAddress] is expected to already be an IPv4 address string
+/// (e.g. from `_controlSocket.address.address`) or `null` if the control
+/// socket is not available / not IPv4.
+///
+/// [candidates] must already be filtered to non-loopback, non-link-local IPv4
+/// addresses; this function does not re-filter them.
+String selectPasvIp({
+  required String? controlSocketAddress,
+  required List<PasvIpCandidate> candidates,
+}) {
+  if (controlSocketAddress != null &&
+      controlSocketAddress.isNotEmpty &&
+      controlSocketAddress != '0.0.0.0' &&
+      !controlSocketAddress.startsWith('127.') &&
+      !controlSocketAddress.startsWith('10.')) {
+    return controlSocketAddress;
+  }
+
+  if (candidates.isEmpty) return '0.0.0.0';
+
+  return candidates.where((c) => c.ifaceName == 'wlan0').firstOrNull?.ip ??
+      candidates.where((c) => c.ifaceName == 'en0').firstOrNull?.ip ??
+      candidates.where((c) => c.ip.startsWith('192.168.')).firstOrNull?.ip ??
+      candidates.where((c) => c.ip.startsWith('172.')).firstOrNull?.ip ??
+      candidates.where((c) => c.ip.startsWith('10.')).firstOrNull?.ip ??
+      candidates.first.ip;
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: ftp_server
 description: "Standards-compliant FTP/FTPS server in Dart. Supports plain FTP and encrypted FTPS (explicit/implicit TLS), read-only and read-write modes, with pluggable file system backends."
-version: 2.3.1
+version: 2.3.2
 homepage: https://github.com/abdelaziz-mahdy/ftp_server
 
 environment:

--- a/test/pasv_ip_selector_test.dart
+++ b/test/pasv_ip_selector_test.dart
@@ -1,0 +1,191 @@
+import 'package:ftp_server/src/pasv_ip_selector.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('selectPasvIp', () {
+    // ---- control socket fast-path ----
+
+    test('control socket 192.168.* is returned directly', () {
+      expect(
+        selectPasvIp(
+          controlSocketAddress: '192.168.1.10',
+          candidates: [
+            (ip: '10.85.1.1', ifaceName: 'rmnet0'),
+          ],
+        ),
+        '192.168.1.10',
+      );
+    });
+
+    test('control socket 172.16.* is returned directly', () {
+      expect(
+        selectPasvIp(
+          controlSocketAddress: '172.16.5.3',
+          candidates: [],
+        ),
+        '172.16.5.3',
+      );
+    });
+
+    test('control socket 10.x falls through to interface scan', () {
+      // Reproduces the Android bug: control socket sees the rmnet 10.x
+      // address, but the real routable address is on wlan0.
+      expect(
+        selectPasvIp(
+          controlSocketAddress: '10.85.1.1',
+          candidates: [
+            (ip: '192.168.1.10', ifaceName: 'wlan0'),
+            (ip: '10.85.1.1', ifaceName: 'rmnet0'),
+          ],
+        ),
+        '192.168.1.10',
+      );
+    });
+
+    test('control socket 0.0.0.0 falls through to interface scan', () {
+      expect(
+        selectPasvIp(
+          controlSocketAddress: '0.0.0.0',
+          candidates: [(ip: '192.168.1.10', ifaceName: 'wlan0')],
+        ),
+        '192.168.1.10',
+      );
+    });
+
+    test('control socket 127.* (loopback) falls through to interface scan', () {
+      expect(
+        selectPasvIp(
+          controlSocketAddress: '127.0.0.1',
+          candidates: [(ip: '192.168.1.10', ifaceName: 'eth0')],
+        ),
+        '192.168.1.10',
+      );
+    });
+
+    test('null control socket falls through to interface scan', () {
+      expect(
+        selectPasvIp(
+          controlSocketAddress: null,
+          candidates: [(ip: '192.168.1.10', ifaceName: 'eth0')],
+        ),
+        '192.168.1.10',
+      );
+    });
+
+    // ---- interface-name priority ----
+
+    test('wlan0 wins over rmnet regardless of candidate order (Android)', () {
+      expect(
+        selectPasvIp(
+          controlSocketAddress: null,
+          candidates: [
+            (ip: '10.85.1.1', ifaceName: 'rmnet0'),
+            (ip: '192.168.1.10', ifaceName: 'wlan0'),
+          ],
+        ),
+        '192.168.1.10',
+      );
+    });
+
+    test('en0 wins when no wlan0 (iOS/macOS)', () {
+      expect(
+        selectPasvIp(
+          controlSocketAddress: null,
+          candidates: [
+            (ip: '192.168.1.20', ifaceName: 'utun0'),
+            (ip: '192.168.1.10', ifaceName: 'en0'),
+          ],
+        ),
+        '192.168.1.10',
+      );
+    });
+
+    test('wlan0 preferred over en0 when both are present', () {
+      expect(
+        selectPasvIp(
+          controlSocketAddress: null,
+          candidates: [
+            (ip: '192.168.1.20', ifaceName: 'en0'),
+            (ip: '192.168.1.10', ifaceName: 'wlan0'),
+          ],
+        ),
+        '192.168.1.10',
+      );
+    });
+
+    // ---- address-range priority ----
+
+    test('192.168.* preferred over 172.* when no named WiFi interface', () {
+      expect(
+        selectPasvIp(
+          controlSocketAddress: null,
+          candidates: [
+            (ip: '172.16.0.5', ifaceName: 'eth1'),
+            (ip: '192.168.1.10', ifaceName: 'eth0'),
+          ],
+        ),
+        '192.168.1.10',
+      );
+    });
+
+    test('172.* preferred over 10.* when no 192.168.* or named WiFi', () {
+      expect(
+        selectPasvIp(
+          controlSocketAddress: null,
+          candidates: [
+            (ip: '10.85.1.1', ifaceName: 'rmnet0'),
+            (ip: '172.16.0.5', ifaceName: 'eth0'),
+          ],
+        ),
+        '172.16.0.5',
+      );
+    });
+
+    test('only 10.x available returns the 10.x (last-resort path)', () {
+      expect(
+        selectPasvIp(
+          controlSocketAddress: null,
+          candidates: [(ip: '10.85.1.1', ifaceName: 'rmnet0')],
+        ),
+        '10.85.1.1',
+      );
+    });
+
+    // ---- fallbacks ----
+
+    test('falls back to first candidate when nothing matches any rule', () {
+      expect(
+        selectPasvIp(
+          controlSocketAddress: null,
+          candidates: [
+            (ip: '100.64.0.1', ifaceName: 'cgnat0'),
+            (ip: '100.64.1.1', ifaceName: 'cgnat1'),
+          ],
+        ),
+        '100.64.0.1',
+      );
+    });
+
+    test('empty candidates with no control socket returns 0.0.0.0', () {
+      expect(
+        selectPasvIp(
+          controlSocketAddress: null,
+          candidates: [],
+        ),
+        '0.0.0.0',
+      );
+    });
+
+    test('empty candidates with 10.x control socket returns 0.0.0.0', () {
+      // The 10.x control socket is rejected, the candidate list is empty —
+      // the function must not loop or throw, just return the sentinel.
+      expect(
+        selectPasvIp(
+          controlSocketAddress: '10.85.1.1',
+          candidates: [],
+        ),
+        '0.0.0.0',
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Problem
On Android, multiple network interfaces exist simultaneously:
- wlan0 → 192.168.1.x (WiFi) ✅
- rmnet → 10.85.x.x (internal) ❌

The previous _getIpAddress() could select the internal 10.x.x.x 
address in the PASV response, causing data connection timeouts 
on Windows FTP clients (FileZilla, Windows Explorer).

## Fix
Updated priority order:
1. Control socket address (most accurate)
2. wlan0 interface (Android WiFi)
3. en0 interface (iOS/macOS WiFi)  
4. 192.168.x.x subnet (home/office router)
5. 172.x.x.x subnet (enterprise network)
6. 10.x.x.x subnet (last resort)

## Testing
Tested on Android with FileZilla in Passive mode.
PASV response now correctly advertises 192.168.x.x instead of 10.x.x.x