### PR TITLE
ci: release automation (build example, multi-platform release, pub.dev publish)

### DIFF
--- a/.github/workflows/build-example.yml
+++ b/.github/workflows/build-example.yml
@@ -1,0 +1,31 @@
+name: Build Example
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    name: Debug Android build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          cache: true
+
+      - name: Install example dependencies
+        run: flutter pub get
+        working-directory: example
+
+      - name: Analyze example
+        run: flutter analyze
+        working-directory: example
+
+      - name: Build debug APK
+        run: flutter build apk --debug
+        working-directory: example

--- a/.github/workflows/build-example.yml
+++ b/.github/workflows/build-example.yml
@@ -13,6 +13,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
       - uses: subosito/flutter-action@v2
         with:
           channel: stable

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,12 @@
+name: Publish to pub.dev
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+*'
+
+jobs:
+  publish:
+    permissions:
+      id-token: write    # required for OIDC authentication with pub.dev
+    uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,137 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  build-android:
+    name: Build example — Android
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          cache: true
+
+      - name: Install example dependencies
+        run: flutter pub get
+        working-directory: example
+
+      - name: Build release APK
+        run: flutter build apk --release
+        working-directory: example
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: example-android
+          path: example/build/app/outputs/flutter-apk/app-release.apk
+          if-no-files-found: error
+
+  build-macos:
+    name: Build example — macOS
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          cache: true
+
+      - name: Install example dependencies
+        run: flutter pub get
+        working-directory: example
+
+      - name: Build release .app
+        run: flutter build macos --release
+        working-directory: example
+
+      - name: Zip macOS .app bundle
+        working-directory: example/build/macos/Build/Products/Release
+        run: zip -r ftp_server_example-macos.zip example.app
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: example-macos
+          path: example/build/macos/Build/Products/Release/ftp_server_example-macos.zip
+          if-no-files-found: error
+
+  build-windows:
+    name: Build example — Windows
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          cache: true
+
+      - name: Install example dependencies
+        run: flutter pub get
+        working-directory: example
+
+      - name: Build release
+        run: flutter build windows --release
+        working-directory: example
+
+      - name: Zip Windows Release directory
+        shell: pwsh
+        run: |
+          Compress-Archive `
+            -Path "example\build\windows\x64\runner\Release\*" `
+            -DestinationPath "ftp_server_example-windows.zip"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: example-windows
+          path: ftp_server_example-windows.zip
+          if-no-files-found: error
+
+  build-linux:
+    name: Build example — Linux
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Linux desktop build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            clang \
+            cmake \
+            ninja-build \
+            pkg-config \
+            libgtk-3-dev \
+            liblzma-dev \
+            libstdc++-12-dev
+
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          cache: true
+
+      - name: Install example dependencies
+        run: flutter pub get
+        working-directory: example
+
+      - name: Build release
+        run: flutter build linux --release
+        working-directory: example
+
+      - name: Tar Linux bundle
+        working-directory: example/build/linux/x64/release
+        run: tar -czf ftp_server_example-linux.tar.gz bundle/
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: example-linux
+          path: example/build/linux/x64/release/ftp_server_example-linux.tar.gz
+          if-no-files-found: error

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
       - uses: subosito/flutter-action@v2
         with:
           channel: stable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,3 +135,56 @@ jobs:
           name: example-linux
           path: example/build/linux/x64/release/ftp_server_example-linux.tar.gz
           if-no-files-found: error
+
+  create-release:
+    name: Create GitHub Release
+    needs:
+      - build-android
+      - build-macos
+      - build-windows
+      - build-linux
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts/
+
+      - name: Extract CHANGELOG section for this version
+        run: |
+          set -euo pipefail
+
+          TAG="${GITHUB_REF_NAME}"
+          VERSION="${TAG#v}"
+
+          awk -v ver="$VERSION" '
+            $0 == "## " ver { printing = 1; next }
+            printing && /^## / { exit }
+            printing { print }
+          ' CHANGELOG.md > release-body.md
+
+          if [ ! -s release-body.md ]; then
+            echo "::error::No CHANGELOG.md section found for version ${VERSION} — expected header '## ${VERSION}'"
+            echo "::error::Add a '## ${VERSION}' entry to CHANGELOG.md before tagging."
+            exit 1
+          fi
+
+          echo "Extracted $(wc -l < release-body.md) lines from CHANGELOG.md for ${VERSION}:"
+          echo "---"
+          cat release-body.md
+          echo "---"
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          body_path: release-body.md
+          append_body: true
+          generate_release_notes: true
+          fail_on_unmatched_files: true
+          files: |
+            artifacts/example-android/app-release.apk
+            artifacts/example-macos/ftp_server_example-macos.zip
+            artifacts/example-windows/ftp_server_example-windows.zip
+            artifacts/example-linux/ftp_server_example-linux.tar.gz

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -29,8 +29,8 @@ android {
     ndkVersion = flutter.ndkVersion
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
 
     defaultConfig {

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-all.zip

--- a/example/android/settings.gradle
+++ b/example/android/settings.gradle
@@ -18,8 +18,8 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "7.3.0" apply false
-    id "org.jetbrains.kotlin.android" version "1.7.10" apply false
+    id "com.android.application" version "8.11.1" apply false
+    id "org.jetbrains.kotlin.android" version "2.2.20" apply false
 }
 
 include ":app"

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -137,7 +137,7 @@ class _FtpServerHomeState extends State<FtpServerHome> {
   }
 
   Future<String?> pickDirectory() async {
-    String? selectedDirectory = await FilePicker.platform.getDirectoryPath();
+    String? selectedDirectory = await FilePicker.getDirectoryPath();
     if (selectedDirectory != null) {
       SharedPreferences prefs = await SharedPreferences.getInstance();
       await prefs.setString('serverDirectory', selectedDirectory);
@@ -519,7 +519,7 @@ class _FtpServerHomeState extends State<FtpServerHome> {
                                 ? null
                                 : () async {
                                     final result =
-                                        await FilePicker.platform.pickFiles(
+                                        await FilePicker.pickFiles(
                                       type: FileType.any,
                                     );
                                     if (result != null) {
@@ -546,7 +546,7 @@ class _FtpServerHomeState extends State<FtpServerHome> {
                                 ? null
                                 : () async {
                                     final result =
-                                        await FilePicker.platform.pickFiles(
+                                        await FilePicker.pickFiles(
                                       type: FileType.any,
                                     );
                                     if (result != null) {

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -518,8 +518,7 @@ class _FtpServerHomeState extends State<FtpServerHome> {
                             onPressed: isServerRunning
                                 ? null
                                 : () async {
-                                    final result =
-                                        await FilePicker.pickFiles(
+                                    final result = await FilePicker.pickFiles(
                                       type: FileType.any,
                                     );
                                     if (result != null) {
@@ -545,8 +544,7 @@ class _FtpServerHomeState extends State<FtpServerHome> {
                             onPressed: isServerRunning
                                 ? null
                                 : () async {
-                                    final result =
-                                        await FilePicker.pickFiles(
+                                    final result = await FilePicker.pickFiles(
                                       type: FileType.any,
                                     );
                                     if (result != null) {

--- a/example/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/example/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,11 +5,13 @@
 import FlutterMacOS
 import Foundation
 
+import file_picker
 import network_info_plus
 import path_provider_foundation
 import shared_preferences_foundation
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
+  FilePickerPlugin.register(with: registry.registrar(forPlugin: "FilePickerPlugin"))
   NetworkInfoPlusPlugin.register(with: registry.registrar(forPlugin: "NetworkInfoPlusPlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -29,10 +29,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   clock:
     dependency: transitive
     description:
@@ -49,6 +49,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.19.1"
+  cross_file:
+    dependency: transitive
+    description:
+      name: cross_file
+      sha256: "28bb3ae56f117b5aec029d702a90f57d285cd975c3c5c281eaca38dbc47c5937"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.5+2"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -61,10 +69,10 @@ packages:
     dependency: transitive
     description:
       name: dbus
-      sha256: "365c771ac3b0e58845f39ec6deebc76e3276aa9922b0cc60840712094d9047ac"
+      sha256: d0c98dcd4f5169878b6cf8f6e0a52403a9dff371a3e2f019697accbf6f44a270
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.12"
   fake_async:
     dependency: transitive
     description:
@@ -93,10 +101,10 @@ packages:
     dependency: "direct main"
     description:
       name: file_picker
-      sha256: be325344c1f3070354a1d84a231a1ba75ea85d413774ec4bdf444c023342e030
+      sha256: f13a03000d942e476bc1ff0a736d2e9de711d2f89a95cd4c1d88f861c3348387
       url: "https://pub.dev"
     source: hosted
-    version: "5.5.0"
+    version: "11.0.2"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -134,7 +142,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.0.0"
+    version: "2.3.2"
   http:
     dependency: transitive
     description:
@@ -163,26 +171,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "6bb818ecbdffe216e81182c2f0714a2e62b593f4a4f13098713ff1685dfb6ab0"
+      sha256: "33e2e26bdd85a0112ec15400c8cbffea70d0f9c3407491f672a2fad47915e2de"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.9"
+    version: "11.0.2"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: f8b613e7e6a13ec79cfdc0e97638fddb3ab848452eff057653abd3edba760573
+      sha256: "1dbc140bb5a23c75ea9c4811222756104fbcd1a27173f0c34ca01e16bea473c1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.9"
+    version: "3.0.10"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
+      sha256: "8d5a2d49f4a66b49744b23b018848400d23e54caf9463f4eb20df3eb8acb2eb1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   lints:
     dependency: transitive
     description:
@@ -203,26 +211,26 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   network_info_plus:
     dependency: "direct main"
     description:
@@ -480,10 +488,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.4"
+    version: "0.7.10"
   typed_data:
     dependency: transitive
     description:
@@ -496,10 +504,10 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.2.0"
   vm_service:
     dependency: transitive
     description:
@@ -541,5 +549,5 @@ packages:
     source: hosted
     version: "6.5.0"
 sdks:
-  dart: ">=3.7.0-0 <4.0.0"
+  dart: ">=3.9.0-0 <4.0.0"
   flutter: ">=3.24.0"

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -35,7 +35,7 @@ dependencies:
   permission_handler: ^11.3.1
   path_provider: ^2.1.3
   shared_preferences: ^2.0.16
-  file_picker: ^5.2.5
+  file_picker: ^11.0.2
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.6


### PR DESCRIPTION
## Summary

Adds three new GitHub Actions workflows that together make `git push origin vX.Y.Z` the complete release action for this repo:

- **`build-example.yml`** — PR/main smoke test: debug Android build of `example/` + `flutter analyze` inside `example/`. Catches example breakage at PR time rather than release time. ~2 min runner time.
- **`release.yml`** — tag-triggered. Builds the example app for **Android, macOS, Windows, and Linux** in parallel, extracts the matching `## X.Y.Z` section from `CHANGELOG.md`, and creates a GitHub Release with the CHANGELOG content as the body (with auto-generated notes appended) and all four binaries attached.
- **`publish.yml`** — tag-triggered. Uses the official `dart-lang/setup-dart/.github/workflows/publish.yml@v1` reusable workflow for OIDC-based pub.dev publishing. No API tokens stored — the trust relationship lives on the pub.dev admin page.

The existing `ci.yml` is untouched.

## Reference

Pattern copied from `/Users/AbdelazizMahdy/flutter_projects/dart_cast/`, with one addition (Linux build) and one generalization (CHANGELOG-sourced release body instead of auto-notes only).

## Key design decisions

- **Four platforms, no iOS/Web.** iOS needs a paid Apple Developer account + signing; Web is a directory of static files with no meaningful single-file delivery format.
- **CHANGELOG hard-fail.** The `create-release` job runs `awk` to extract the `## 2.3.3` section of `CHANGELOG.md`. If the matching header is missing, the job fails with `::error::` — forgetting to update CHANGELOG before tagging is a mistake we want to catch, not paper over.
- **\`fail_on_unmatched_files: true\`** on the release step as a third safety net: if any of the four artifacts is somehow missing at release time, no release is created.
- **Stricter tag pattern for pub.dev** (`v[0-9]+.[0-9]+.[0-9]+*`) than for GitHub Release (`v*`). Experimental tags like `v2.3.3-wip` build and release artifacts but skip pub.dev.

## Follow-up after merge (not in this PR)

1. One-time pub.dev admin setup: enable "Publishing from GitHub Actions" for `ftp_server` at https://pub.dev/packages/ftp_server/admin with tag pattern `v{{version}}`. Without this, `publish.yml` fails at the OIDC exchange on first run.
2. Back-fill `v2.3.2`: delete + re-push the existing `v2.3.2` tag at the merge commit so the new automation creates a GitHub Release with example binaries and publishes `ftp_server 2.3.2` to pub.dev. (Tag mutation is safe here because `v2.3.2` has no consumer state yet — no existing Release, not on pub.dev.)

## Test plan

- [ ] `build-example.yml` runs green on this PR (Android debug build + flutter analyze inside example/)
- [ ] Existing `ci.yml` still runs green on this PR
- [ ] After merge: push back-filled `v2.3.2` tag, observe `release.yml` producing four artifacts and creating the GitHub Release
- [ ] After merge + pub.dev admin setup: observe `publish.yml` publishing `2.3.2` to pub.dev
- [ ] Download one release artifact (Linux tarball) and verify it contains `bundle/example` executable